### PR TITLE
Migrate from subdomain to path-based routing

### DIFF
--- a/.env.self-hosted.example
+++ b/.env.self-hosted.example
@@ -16,9 +16,12 @@ JWT_PUBLIC_KEY_PATH=/app/keys/public.pem
 # Envelope encryption key (generate with: python3 -c "import os,base64; print(base64.b64encode(os.urandom(32)).decode())")
 ENCRYPTION_KEK_B64=
 
-# Your domain (required for namespace subdomains)
+# Your domain (used for URL generation; not required for local installs)
 BASE_DOMAIN=example.com
 BASE_SCHEME=https
+
+# Routing mode: "path" (default, recommended), "subdomain" (legacy), "both" (transition)
+ROUTING_MODE=path
 
 # === RECOMMENDED ===
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This file provides guidance to AI coding assistants (Claude Code, Copilot, Curso
 **License:** BSL 1.1 (open-source, self-hostable)
 
 **Architecture:** RESTful API + MCP namespace endpoints (direct HTTPS, no proxy)
-- Namespace endpoints: `{ns}.create.mcpworks.io` (manage) / `{ns}.run.mcpworks.io` (execute)
+- MCP endpoints: `/mcp/create/{ns}` (manage) / `/mcp/run/{ns}` (execute) / `/mcp/agent/{ns}` (agents)
 - API endpoints: `https://api.mcpworks.io/v1/`
 - Function execution: Code Sandbox (nsjail) with Python/TypeScript support
 - Agent runtime: Autonomous agents with scheduling, state, webhooks, BYOAI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - REST API for account management, authentication (JWT + OAuth2), and usage tracking
 - Subscription-based billing via Stripe
 - Docker Compose self-hosting with bundled PostgreSQL and Redis
-- Caddy reverse proxy with automatic TLS and wildcard subdomain routing
+- Caddy reverse proxy with automatic TLS and path-based routing
 - Envelope encryption (AES-256-GCM) for stored secrets
 - Credential scanning for user-submitted code
 - Comprehensive spec-driven development documentation

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,17 +1,14 @@
 # MCPWorks Production Caddyfile
-# Caddy automatically provisions SSL via Let's Encrypt
+# All MCP traffic routes through api.mcpworks.io using path-based routing:
+#   /mcp/create/{namespace}  — management
+#   /mcp/run/{namespace}     — execution
+#   /mcp/agent/{namespace}   — agent webhooks/chat/view
 
 {
     email admin@mcpworks.io
-
-    # On-demand TLS for namespace subdomains
-    # Individual certs are issued as subdomains are accessed
-    on_demand_tls {
-        ask http://api:8000/v1/internal/verify-domain
-    }
 }
 
-# Main API endpoint
+# Main API endpoint — handles ALL traffic (REST + MCP)
 api.mcpworks.io {
     # ORDER-015: Use readiness check for upstream health
     reverse_proxy api:8000 {
@@ -40,71 +37,39 @@ api.mcpworks.io {
     }
 }
 
-# Namespace Management Interface (*.create.mcpworks.io)
-*.create.mcpworks.io {
-    tls {
-        on_demand
-    }
+# ──────────────────────────────────────────────────────────────
+# DEPRECATED: Wildcard subdomain blocks (transition period)
+#
+# These exist for backward compatibility with clients still using
+# subdomain-based URLs like {ns}.create.mcpworks.io.
+# Set ROUTING_MODE=both in the API to enable.
+# Remove after transition period (90 days from 2026-03-30).
+# ──────────────────────────────────────────────────────────────
 
-    reverse_proxy api:8000
-
-    # Security headers
-    header {
-        X-Content-Type-Options nosniff
-        X-Frame-Options DENY
-        Referrer-Policy strict-origin-when-cross-origin
-        -Server
-    }
-
-    log {
-        output stdout
-        format json
-    }
-}
-
-# Namespace Execution Interface (*.run.mcpworks.io)
-*.run.mcpworks.io {
-    tls {
-        on_demand
-    }
-
-    reverse_proxy api:8000
-
-    # Security headers
-    header {
-        X-Content-Type-Options nosniff
-        X-Frame-Options DENY
-        Referrer-Policy strict-origin-when-cross-origin
-        -Server
-    }
-
-    log {
-        output stdout
-        format json
-    }
-}
-
-# Agent Webhook Interface (*.agent.mcpworks.io)
-# All traffic routed to API; API handles webhook forwarding to agent containers
-*.agent.mcpworks.io {
-    tls {
-        on_demand
-    }
-
-    reverse_proxy api:8000
-
-    header {
-        X-Content-Type-Options nosniff
-        X-Frame-Options DENY
-        Referrer-Policy strict-origin-when-cross-origin
-        -Server
-    }
-
-    log {
-        output stdout
-        format json
-    }
-}
+# (Commented out — uncomment if ROUTING_MODE=both is needed)
+#
+# # On-demand TLS for wildcard subdomains (requires DNS-01 or on_demand)
+# # on_demand_tls {
+# #     ask http://api:8000/v1/internal/verify-domain
+# # }
+#
+# *.create.mcpworks.io {
+#     tls { on_demand }
+#     reverse_proxy api:8000
+#     header { X-Content-Type-Options nosniff; X-Frame-Options DENY; -Server }
+# }
+#
+# *.run.mcpworks.io {
+#     tls { on_demand }
+#     reverse_proxy api:8000
+#     header { X-Content-Type-Options nosniff; X-Frame-Options DENY; -Server }
+# }
+#
+# *.agent.mcpworks.io {
+#     tls { on_demand }
+#     reverse_proxy api:8000
+#     header { X-Content-Type-Options nosniff; X-Frame-Options DENY; -Server }
+# }
 
 # Health check endpoint (no SSL required)
 :80 {

--- a/SPEC.md
+++ b/SPEC.md
@@ -50,7 +50,7 @@ The **mcpworks-api** is the backend service powering the MCPWorks namespace-base
          ┌───────────┴───────────┐
          ▼                       ▼
 ┌─────────────────────┐  ┌─────────────────────┐
-│ {ns}.create.mcpworks│  │ {ns}.run.mcpworks.io│
+│ /mcp/create/{ns}    │  │ /mcp/run/{ns}       │
 │ Management (CRUD)   │  │ Execution           │
 └─────────┬───────────┘  └─────────┬───────────┘
           │                        │
@@ -66,7 +66,7 @@ The **mcpworks-api** is the backend service powering the MCPWorks namespace-base
 │                          ▼                              │
 │  ┌─────────────────────────────────────────────────┐   │
 │  │ Middleware Stack                                 │   │
-│  │ MCPTransport → Billing → RateLimit → Subdomain  │   │
+│  │ MCPTransport → Billing → RateLimit → PathRouting│   │
 │  └─────────────────────────────────────────────────┘   │
 └────────┬───────────┬───────────┬─────────────┬──────────┘
          │           │           │             │
@@ -81,10 +81,10 @@ The **mcpworks-api** is the backend service powering the MCPWorks namespace-base
 
 | Pattern | Purpose |
 |---------|---------|
-| `{namespace}.create.mcpworks.io` | Management interface — CRUD functions, services, agents |
-| `{namespace}.run.mcpworks.io` | Execution interface — call functions, run code |
-| `{agent}.agent.mcpworks.io` | Agent webhook ingress |
-| `api.mcpworks.io` | REST API — auth, billing, admin |
+| `/mcp/create/{namespace}` | Management interface — CRUD functions, services, agents |
+| `/mcp/run/{namespace}` | Execution interface — call functions, run code |
+| `/mcp/agent/{namespace}` | Agent MCP + webhook ingress |
+| `/v1/*` | REST API — auth, billing, admin |
 
 ### Function Backends
 
@@ -98,10 +98,10 @@ The **mcpworks-api** is the backend service powering the MCPWorks namespace-base
 
 1. **CorrelationIdMiddleware** — assigns request trace ID
 2. **RequestLoggingMiddleware** — structured JSON logging (structlog)
-3. **SubdomainMiddleware** — parses `{ns}.{type}.mcpworks.io` → namespace + endpoint type
+3. **PathRoutingMiddleware** — parses `/mcp/{type}/{ns}` → namespace + endpoint type
 4. **RateLimitMiddleware** — auth rate limits, per-IP throttling
 5. **BillingMiddleware** — monthly quota, per-minute rate, concurrency enforcement
-6. **MCPTransportMiddleware** — intercepts `/mcp` → JSON-RPC 2.0 dispatch
+6. **MCPTransportMiddleware** — intercepts `/mcp/{endpoint}/{ns}` → JSON-RPC 2.0 dispatch
 
 ---
 
@@ -276,7 +276,7 @@ Per PRICING.md v7.0.0. All accounts have agent functionality.
 
 AI assistants connect via JSON-RPC 2.0 over HTTPS. Two endpoint types:
 
-### Create Interface (`{ns}.create.mcpworks.io/mcp`)
+### Create Interface (`/mcp/create/{ns}`)
 
 Management tools for building and configuring.
 
@@ -310,7 +310,7 @@ Management tools for building and configuring.
 
 **Tool Scopes:** Each tool requires `read` or `write` scope on the API key.
 
-### Run Interface (`{ns}.run.mcpworks.io/mcp`)
+### Run Interface (`/mcp/run/{ns}`)
 
 Execution tools, dynamically generated from namespace functions.
 
@@ -433,7 +433,7 @@ Checkout automatically maps to agent tiers (e.g., `pro` → `pro-agent`).
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/webhook/{path}` | Incoming webhook (routed by `{agent}.agent.mcpworks.io`) |
+| POST | `/mcp/agent/{agent}/webhook/{path}` | Incoming webhook |
 
 ### Health
 

--- a/alembic/versions/20260319_000003_add_chat_token_to_agents.py
+++ b/alembic/versions/20260319_000003_add_chat_token_to_agents.py
@@ -1,7 +1,7 @@
 """Add chat_token to agents.
 
 Public chat endpoint authentication via obfuscated URL token.
-Pattern: POST https://{agent}.agent.mcpworks.io/chat/{token}
+Pattern: POST /mcp/agent/{agent}/chat/{token}
 
 Revision ID: 20260319_000003
 Revises: 20260319_000002

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -10,7 +10,7 @@ From zero to running your first function. This guide covers deploying MCPWorks o
 | Docker | 24.0+ | With Docker Compose v2 |
 | RAM | 2 GB | 4 GB recommended |
 | Disk | 20 GB | SSD recommended |
-| Domain | Wildcard DNS | Required for namespace subdomains |
+| Domain | Optional | Not required — path-based routing works with IP address only |
 | Ports | 80, 443 | Must be open for Let's Encrypt |
 
 ## 1. Clone and Generate Keys
@@ -92,7 +92,7 @@ Open `https://api.<your-domain>/console` in your browser and log in.
 
 The console walks you through three setup steps:
 
-1. **Create a namespace** — this becomes your subdomain prefix (e.g. `demo.create.<your-domain>`)
+1. **Create a namespace** — this becomes your MCP endpoint path (e.g. `/mcp/create/demo`)
 2. **Create an API key** — starts with `sk_live_`, shown only once — copy it
 3. **Connect your AI assistant** — the console generates the `.mcp.json` config for Claude Code, Cursor, and other clients, pre-filled with your namespace URLs and API key
 
@@ -309,7 +309,7 @@ All services run in Docker containers on a single machine. For high-availability
 
 | Concept | What it does |
 |---------|-------------|
-| **Namespace** | Top-level container, maps to `{ns}.create.` and `{ns}.run.` subdomains |
+| **Namespace** | Top-level container, maps to `/mcp/create/{ns}` and `/mcp/run/{ns}` endpoints |
 | **Service** | Groups related functions (like a folder) |
 | **Function** | Executable code with input/output schemas |
 | **Code mode** | AI writes Python that calls your functions inside the sandbox |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -34,12 +34,12 @@ Deploy it on your own infrastructure, write a function, and it runs.
 
 ### Namespaces
 
-A namespace is your top-level organizational unit. It maps to a subdomain pair:
+A namespace is your top-level organizational unit. It maps to a pair of MCP endpoints:
 
-- `{ns}.create.{BASE_DOMAIN}` — management
-- `{ns}.run.{BASE_DOMAIN}` — execution
+- `/mcp/create/{ns}` — management
+- `/mcp/run/{ns}` — execution
 
-Namespace names must be DNS-compliant: lowercase alphanumeric with hyphens, 1–63 characters, must start and end with an alphanumeric character.
+Namespace names must be lowercase alphanumeric with hyphens, 1–63 characters, must start and end with an alphanumeric character.
 
 ### Services
 

--- a/docs/implementation/database-models-specification.md
+++ b/docs/implementation/database-models-specification.md
@@ -168,7 +168,7 @@ class Namespace(Base, UUIDMixin, TimestampMixin):
     Namespace model for organizing functions and services.
 
     Namespaces provide:
-    - Unique DNS subdomain ({namespace}.create.mcpworks.io, {namespace}.run.mcpworks.io)
+    - Unique MCP endpoint (/mcp/create/{namespace}, /mcp/run/{namespace})
     - Resource isolation between accounts
     - Network security controls (IP allowlisting)
     - Organizational boundary for services and functions
@@ -1216,12 +1216,12 @@ class NamespaceResponse(NamespaceBase):
     @property
     def create_endpoint(self) -> str:
         """Compute create endpoint URL."""
-        return f"https://{self.name}.create.mcpworks.io"
+        return url_builder.create_url(self.name)
 
     @property
     def run_endpoint(self) -> str:
         """Compute run endpoint URL."""
-        return f"https://{self.name}.run.mcpworks.io"
+        return url_builder.run_url(self.name)
 
 
 class NamespaceList(BaseModel):

--- a/docs/implementation/specs/api-contract.md
+++ b/docs/implementation/specs/api-contract.md
@@ -34,7 +34,7 @@ Authorization: Bearer {api_key_or_access_token}
 
 ### 1.3 Environment Variable Passthrough
 
-Functions that call external APIs can receive secrets via the `X-MCPWorks-Env` header on **run** endpoint requests (`*.run.mcpworks.io`). Values are never stored, logged, or persisted — they exist only for the duration of execution.
+Functions that call external APIs can receive secrets via the `X-MCPWorks-Env` header on **run** endpoint requests (`/mcp/run/{namespace}`). Values are never stored, logged, or persisted — they exist only for the duration of execution.
 
 ```
 X-MCPWorks-Env: base64:{base64-encoded JSON object}

--- a/docs/implementation/specs/env-passthrough.md
+++ b/docs/implementation/specs/env-passthrough.md
@@ -57,7 +57,7 @@ Function authors need their code to call external APIs (OpenAI, Stripe, database
 
 **Workflow:**
 1. Developer configures `.mcp.json` with the `X-MCPWorks-Env` header containing their base64-encoded env vars
-2. Claude Code connects to `acme.run.mcpworks.io` and sends the header on every request
+2. Claude Code connects to `/mcp/run/acme` and sends the header on every request
 3. AI assistant calls `tools/list`, sees "Required env: OPENAI_API_KEY" in the tool description
 4. AI assistant calls `tools.search` with arguments
 5. Server extracts env vars from header, filters to only `OPENAI_API_KEY` (what the function declared), writes to tmpfs
@@ -552,7 +552,7 @@ Support `X-MCPWorks-Env-{NAME}: {value}` as an alternative to the single base64 
   "mcpServers": {
     "acme": {
       "type": "http",
-      "url": "https://acme.run.mcpworks.io/mcp",
+      "url": "https://api.mcpworks.io/mcp/run/acme",
       "headers": {
         "Authorization": "Bearer ${MCPWORKS_API_KEY}",
         "X-MCPWorks-Env": "${MCPWORKS_ACME_ENV}"

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -406,7 +406,7 @@ make_function(
 | `No code provided` | Empty code in execute/make_function | Provide code or use a template |
 | `Invalid tool name format` | Tool mode name missing `.` | Use `service.function` format |
 | `Authentication failed` | Bad or missing API key | Check Authorization header |
-| `INVALID_HOST` | Wrong subdomain format | Use `{ns}.{create|run}.{BASE_DOMAIN}` |
+| `INVALID_ENDPOINT` | Invalid endpoint type | Use `/mcp/{create|run|agent}/{namespace}` |
 
 ---
 

--- a/docs/specs/AGENTS-TECH-SPEC.md
+++ b/docs/specs/AGENTS-TECH-SPEC.md
@@ -330,41 +330,24 @@ class AgentService:
 
 ### DNS
 
-Cloudflare already has wildcard `*.mcpworks.io`. Add:
-- `*.agent.mcpworks.io` → A record → `<prod-server-ip>` (same droplet initially)
+With path-based routing, all traffic goes through `api.mcpworks.io`. No additional DNS records needed for agents.
 
 ### Caddy Routing
 
-Add to Caddyfile:
+All agent traffic is handled via path-based routing through the main `api.mcpworks.io` block. Agent endpoints:
+- `/mcp/agent/{name}` — MCP protocol
+- `/mcp/agent/{name}/webhook/{path}` — webhook ingress
+- `/mcp/agent/{name}/chat/{token}` — public chat
+- `/mcp/agent/{name}/view/{token}/` — scratchpad view
 
-```
-*.agent.mcpworks.io {
-    tls {
-        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
-    }
-
-    @webhook path /webhook/*
-
-    handle @webhook {
-        reverse_proxy mcpworks-api:8000
-    }
-
-    handle {
-        reverse_proxy mcpworks-api:8000
-    }
-}
-```
-
-All `*.agent.mcpworks.io` traffic routes to the API server. The API server inspects the `Host` header, resolves the agent name, and either:
-- Forwards webhook payloads to the agent container (via Docker network)
-- Handles MCP protocol requests directly
+The API server's `PathRoutingMiddleware` extracts the agent name from the URL path and routes to the appropriate handler.
 
 ### Webhook Ingress Path
 
 ```
 External system
     │
-    │ POST https://dogedetective.agent.mcpworks.io/webhook/price-alert
+    │ POST https://api.mcpworks.io/mcp/agent/dogedetective/webhook/price-alert
     │
     ├── Cloudflare (DDoS, TLS termination)
     ├── Caddy (TLS, reverse proxy)
@@ -408,7 +391,7 @@ from apscheduler.triggers.cron import CronTrigger
 scheduler = AsyncIOScheduler()
 
 async def execute_scheduled_function(schedule_id: str, function_name: str):
-    # Call {namespace}.run.mcpworks.io to execute the function
+    # Call /mcp/run/{namespace} to execute the function
     # Record AgentRun
     pass
 
@@ -599,7 +582,7 @@ The existing admin dashboard (if web-based) or admin API needs:
 | Droplet | s-2vcpu-4gb ($24/mo) | s-4vcpu-8gb ($48/mo) |
 | Docker | Running API + Caddy | + agent containers |
 | Network | Single bridge | + `mcpworks-agents` bridge |
-| DNS | `*.mcpworks.io` wildcard | + `*.agent.mcpworks.io` (same wildcard covers it) |
+| DNS | `api.mcpworks.io` A record | Path-based routing — no wildcard DNS needed |
 
 ### Resource Budget (s-4vcpu-8gb = 8 GB RAM, 4 vCPU)
 

--- a/infra/SCALING.md
+++ b/infra/SCALING.md
@@ -153,7 +153,7 @@ Add a second API box behind a load balancer. Split sandbox execution to a dedica
 | **Total** | | **$270** |
 
 **Actions:**
-1. **DO Load Balancer** — $12/mo. Health check on `/v1/health`. Round-robin distribution. No sticky sessions needed (stateless JWT + stateless MCP). Wildcard TLS for `*.create.mcpworks.io` and `*.run.mcpworks.io` terminated at the LB.
+1. **DO Load Balancer** — $12/mo. Health check on `/v1/health`. Round-robin distribution. No sticky sessions needed (stateless JWT + stateless MCP). Single TLS cert for `api.mcpworks.io` terminated at the LB (path-based routing — no wildcard certs needed).
 2. **Second API droplet** — Identical container deployment. PgBouncer on each box. Since MCP transport is stateless and auth is JWT-based, no session synchronization needed.
 3. **Sandbox worker** — Dedicated droplet running only sandbox executions. API dispatches execution requests to the worker via a Redis task queue (Celery with Redis broker, or a lightweight asyncio consumer). This isolates sandbox resource usage from API request handling.
 4. **Task queue for sandbox** — Replace direct `asyncio.create_subprocess_exec()` with a Celery task (or Redis Streams consumer). API enqueues `{code, env, tier, timeout}`, worker dequeues and executes in nsjail, returns result. Timeout and retry handled at the queue level.
@@ -317,7 +317,7 @@ Use Celery with Redis broker. Worker runs with `--concurrency=8` (or tuned per t
 
 - **Algorithm:** Round-robin (all API boxes are identical)
 - **Health check:** HTTP GET `/v1/health` every 10s, 3 failures = remove from pool
-- **TLS:** Wildcard cert for `*.create.mcpworks.io` and `*.run.mcpworks.io` via Let's Encrypt. Caddy on each API box handles app-level TLS; LB does TCP passthrough, OR LB terminates TLS and forwards HTTP internally.
+- **TLS:** Single cert for `api.mcpworks.io` via Let's Encrypt (path-based routing — no wildcard certs needed). LB terminates TLS and forwards HTTP internally.
 - **Sticky sessions:** Not needed. JWT auth is stateless, MCP transport is stateless.
 - **Websockets/SSE:** LB supports forwarding. No special config.
 
@@ -502,7 +502,7 @@ DO App Platform and similar managed container services add cost and reduce contr
 □ Deploy identical API stack to second droplet
 □ Provision DO Load Balancer, add both API droplets as targets
 □ Update DNS: api.mcpworks.io → LB IP
-□ Update wildcard DNS: *.create.mcpworks.io, *.run.mcpworks.io → LB IP
+□ Verify api.mcpworks.io DNS points to LB IP (path-based routing — no wildcard DNS needed)
 □ Test health check failover (stop one API box, verify traffic routes to other)
 □ Replace asyncio.create_task() fire-and-forget with Celery tasks for security events
 □ Upgrade managed Postgres if connection count requires it

--- a/infra/edge/Caddyfile
+++ b/infra/edge/Caddyfile
@@ -1,16 +1,17 @@
 # MCPWorks Edge Caddyfile — api.mcpworks.io
 # This server is a TLS-terminating reverse proxy only.
 # All application services run on server0.pop11 (10.100.0.3) via WireGuard.
+#
+# All MCP traffic routes through api.mcpworks.io using path-based routing:
+#   /mcp/create/{namespace}  — management
+#   /mcp/run/{namespace}     — execution
+#   /mcp/agent/{namespace}   — agent webhooks/chat/view
 
 {
     email admin@mcpworks.io
-
-    on_demand_tls {
-        ask http://10.100.0.3:8000/v1/internal/verify-domain
-    }
 }
 
-# Main API endpoint
+# Main API endpoint — handles ALL traffic (REST + MCP)
 api.mcpworks.io {
     reverse_proxy 10.100.0.3:8000 {
         health_uri /v1/health/ready
@@ -35,68 +36,38 @@ api.mcpworks.io {
     }
 }
 
-# Namespace Management Interface (*.create.mcpworks.io)
-*.create.mcpworks.io {
-    tls {
-        on_demand
-    }
+# ──────────────────────────────────────────────────────────────
+# DEPRECATED: Wildcard subdomain blocks (transition period)
+#
+# These exist for backward compatibility with clients still using
+# subdomain-based URLs like {ns}.create.mcpworks.io.
+# Set ROUTING_MODE=both in the API to enable.
+# Remove after transition period (90 days from 2026-03-30).
+# ──────────────────────────────────────────────────────────────
 
-    reverse_proxy 10.100.0.3:8000
-
-    header {
-        X-Content-Type-Options nosniff
-        X-Frame-Options DENY
-        Referrer-Policy strict-origin-when-cross-origin
-        -Server
-    }
-
-    log {
-        output stdout
-        format json
-    }
-}
-
-# Namespace Execution Interface (*.run.mcpworks.io)
-*.run.mcpworks.io {
-    tls {
-        on_demand
-    }
-
-    reverse_proxy 10.100.0.3:8000
-
-    header {
-        X-Content-Type-Options nosniff
-        X-Frame-Options DENY
-        Referrer-Policy strict-origin-when-cross-origin
-        -Server
-    }
-
-    log {
-        output stdout
-        format json
-    }
-}
-
-# Agent Webhook Interface (*.agent.mcpworks.io)
-*.agent.mcpworks.io {
-    tls {
-        on_demand
-    }
-
-    reverse_proxy 10.100.0.3:8000
-
-    header {
-        X-Content-Type-Options nosniff
-        X-Frame-Options DENY
-        Referrer-Policy strict-origin-when-cross-origin
-        -Server
-    }
-
-    log {
-        output stdout
-        format json
-    }
-}
+# (Commented out — uncomment if ROUTING_MODE=both is needed)
+#
+# on_demand_tls {
+#     ask http://10.100.0.3:8000/v1/internal/verify-domain
+# }
+#
+# *.create.mcpworks.io {
+#     tls { on_demand }
+#     reverse_proxy 10.100.0.3:8000
+#     header { X-Content-Type-Options nosniff; X-Frame-Options DENY; -Server }
+# }
+#
+# *.run.mcpworks.io {
+#     tls { on_demand }
+#     reverse_proxy 10.100.0.3:8000
+#     header { X-Content-Type-Options nosniff; X-Frame-Options DENY; -Server }
+# }
+#
+# *.agent.mcpworks.io {
+#     tls { on_demand }
+#     reverse_proxy 10.100.0.3:8000
+#     header { X-Content-Type-Options nosniff; X-Frame-Options DENY; -Server }
+# }
 
 # GenOps (genops.dev) -> server1.pop11
 genops.dev {

--- a/specs/015-path-based-routing/checklists/requirements.md
+++ b/specs/015-path-based-routing/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Requirements Checklist: Path-Based Routing
+
+## Functional Requirements
+
+- [ ] FR-001: API accepts MCP requests at `/mcp/{endpoint}/{namespace}`
+- [ ] FR-002: Path params populate `request.state` identically to SubdomainMiddleware
+- [ ] FR-003: `url_builder` generates path-based URLs with config toggle
+- [ ] FR-004: Agent sub-paths work under path-based scheme
+- [ ] FR-005: SubdomainMiddleware remains functional when `ROUTING_MODE=subdomain|both`
+- [ ] FR-006: All response URLs use path-based format when `ROUTING_MODE=path`
+- [ ] FR-007: `GET /mcp` returns protocol discovery info
+
+## Non-Functional Requirements
+
+- [ ] NFR-001: Zero performance regression
+- [ ] NFR-002: Self-host works with IP address only (no DNS/TLS)
+- [ ] NFR-003: Single origin for all MCP traffic
+
+## User Stories
+
+- [ ] US-1: Self-hosted MCP connection via path-based URL
+- [ ] US-2: Cloud MCP connection via path-based URL
+- [ ] US-3: Backward compatibility with subdomain URLs (transition period)
+- [ ] US-4: Agent webhooks/chat/view via path-based URLs
+
+## Security
+
+- [ ] Path traversal prevented by namespace validation regex
+- [ ] Auth enforcement identical to subdomain routing
+- [ ] No namespace enumeration beyond what DNS already exposes
+
+## Testing
+
+- [ ] Unit tests for PathRoutingMiddleware
+- [ ] Unit tests for url_builder (both modes)
+- [ ] Integration tests for MCP create/run flows
+- [ ] Integration tests for agent sub-routes
+- [ ] Backward compatibility tests

--- a/specs/015-path-based-routing/contracts/url-patterns.md
+++ b/specs/015-path-based-routing/contracts/url-patterns.md
@@ -1,0 +1,135 @@
+# API Contract: Path-Based URL Patterns
+
+## MCP Endpoints
+
+### Core MCP (JSON-RPC over Streamable HTTP)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/mcp/create/{namespace}` | MCP create (management) endpoint |
+| POST | `/mcp/run/{namespace}` | MCP run (execution) endpoint |
+| POST | `/mcp/agent/{namespace}` | MCP agent endpoint |
+| GET | `/mcp/create/{namespace}` | SSE reconnection (create) |
+| GET | `/mcp/run/{namespace}` | SSE reconnection (run) |
+| GET | `/mcp/agent/{namespace}` | SSE reconnection (agent) |
+| DELETE | `/mcp/create/{namespace}` | Session termination (create) |
+| DELETE | `/mcp/run/{namespace}` | Session termination (run) |
+| DELETE | `/mcp/agent/{namespace}` | Session termination (agent) |
+
+### Agent Sub-Routes
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/mcp/agent/{namespace}/webhook/{path:path}` | Webhook ingress |
+| POST | `/mcp/agent/{namespace}/chat/{token}` | Public chat message |
+| GET | `/mcp/agent/{namespace}/view/{token}/` | Scratchpad view (HTML) |
+
+### Discovery
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/mcp` | Protocol discovery |
+
+## Path Parameter Constraints
+
+### `{namespace}`
+
+- Regex: `[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?`
+- Min length: 1
+- Max length: 63
+- Allowed chars: lowercase alphanumeric and hyphens
+- Cannot start or end with hyphen
+
+### `{endpoint}`
+
+- Enum: `create`, `run`, `agent`
+- Any other value returns 404
+
+### `{path}` (webhook sub-path)
+
+- Free-form path segments (captured by FastAPI's `{path:path}`)
+- Example: `github/push`, `stripe/invoice`
+
+### `{token}`
+
+- Opaque string, validated by the handler
+
+## Discovery Response
+
+```json
+GET /mcp
+
+{
+  "protocol": "mcp",
+  "version": "2024-11-05",
+  "url_template": "/mcp/{endpoint}/{namespace}",
+  "endpoints": ["create", "run", "agent"],
+  "docs": "/docs/quickstart"
+}
+```
+
+## URL Builder Output Examples
+
+### ROUTING_MODE=path (default)
+
+```
+create_url("acme")     → https://api.mcpworks.io/mcp/create/acme
+run_url("acme")        → https://api.mcpworks.io/mcp/run/acme
+agent_url("mybot")     → https://api.mcpworks.io/mcp/agent/mybot
+mcp_url("acme", "run") → https://api.mcpworks.io/mcp/run/acme
+view_url("mybot", "t") → https://api.mcpworks.io/mcp/agent/mybot/view/t/
+chat_url("mybot", "t") → https://api.mcpworks.io/mcp/agent/mybot/chat/t
+```
+
+### ROUTING_MODE=subdomain (legacy)
+
+```
+create_url("acme")     → https://acme.create.mcpworks.io
+run_url("acme")        → https://acme.run.mcpworks.io
+agent_url("mybot")     → https://mybot.agent.mcpworks.io
+mcp_url("acme", "run") → https://acme.run.mcpworks.io/mcp
+view_url("mybot", "t") → https://mybot.agent.mcpworks.io/view/t/
+chat_url("mybot", "t") → https://mybot.agent.mcpworks.io/chat/t
+```
+
+## Deprecation Headers
+
+When a request arrives via subdomain routing (and `ROUTING_MODE=both`):
+
+```
+X-MCPWorks-Deprecated: subdomain-routing; migrate to /mcp/{endpoint}/{namespace}
+```
+
+## Error Responses
+
+### Invalid endpoint type
+
+```
+GET /mcp/invalid/acme → 404
+
+{
+  "detail": {
+    "code": "INVALID_ENDPOINT",
+    "message": "Invalid endpoint 'invalid'. Must be one of: create, run, agent"
+  }
+}
+```
+
+### Missing namespace
+
+```
+GET /mcp/create → 404 (FastAPI default — no route match)
+```
+
+### Invalid namespace format
+
+```
+GET /mcp/create/UPPERCASE → 400
+
+{
+  "detail": {
+    "code": "INVALID_NAMESPACE",
+    "message": "Invalid namespace 'UPPERCASE'. Must match [a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
+  }
+}
+```

--- a/specs/015-path-based-routing/plan.md
+++ b/specs/015-path-based-routing/plan.md
@@ -1,0 +1,210 @@
+# Implementation Plan: Path-Based Routing
+
+**Spec**: [015-path-based-routing/spec.md](spec.md)
+**Created**: 2026-03-30
+**Status**: Draft
+
+## Architecture Overview
+
+### Current Flow (Subdomain)
+
+```
+Client → acme.create.mcpworks.io/mcp
+       → Caddy (wildcard TLS) → API :8000
+       → SubdomainMiddleware extracts namespace="acme", endpoint="create"
+       → MCPTransportMiddleware intercepts /mcp path
+       → MCP handlers read request.state.namespace, request.state.endpoint_type
+```
+
+### New Flow (Path-Based)
+
+```
+Client → api.mcpworks.io/mcp/create/acme
+       → Caddy (single cert) → API :8000
+       → PathRoutingMiddleware extracts namespace="acme", endpoint="create"
+       → MCPTransportMiddleware intercepts /mcp/* paths
+       → MCP handlers read request.state.namespace, request.state.endpoint_type
+         (unchanged — same request.state contract)
+```
+
+The key insight: **everything downstream of `request.state` is unchanged**. The refactor is entirely in how `request.state.namespace` and `request.state.endpoint_type` get populated.
+
+## Technical Approach
+
+### Phase 1: Path Extraction Middleware (replaces SubdomainMiddleware)
+
+Create `middleware/routing.py` that:
+
+1. Matches requests to `/mcp/{endpoint}/{namespace}` and `/mcp/{endpoint}/{namespace}/{subpath:path}`
+2. Sets `request.state.namespace` and `request.state.endpoint_type` (same contract as SubdomainMiddleware)
+3. Rewrites `request.scope["path"]` so downstream sees `/mcp` (preserving MCPTransportMiddleware compatibility) or the appropriate sub-path for agent routes
+
+**Path patterns to handle:**
+
+| Pattern | Meaning |
+|---------|---------|
+| `POST /mcp/create/{ns}` | MCP create endpoint |
+| `POST /mcp/run/{ns}` | MCP run endpoint |
+| `POST /mcp/agent/{ns}` | MCP agent endpoint |
+| `GET /mcp/create/{ns}` | MCP SSE reconnection |
+| `GET /mcp/run/{ns}` | MCP SSE reconnection |
+| `DELETE /mcp/create/{ns}` | MCP session termination |
+| `POST /mcp/agent/{ns}/webhook/{path}` | Agent webhook ingress |
+| `POST /mcp/agent/{ns}/chat/{token}` | Agent public chat |
+| `GET /mcp/agent/{ns}/view/{token}/` | Agent scratchpad view |
+| `GET /mcp` | Discovery endpoint |
+
+### Phase 2: Config Toggle
+
+Add `ROUTING_MODE` setting to `config.py`:
+
+```python
+routing_mode: Literal["path", "subdomain", "both"] = Field(
+    default="path",
+    description="URL routing strategy: path (/mcp/create/ns), subdomain (ns.create.domain), or both",
+)
+```
+
+- `path` (default): Only PathRoutingMiddleware is active. SubdomainMiddleware is not added.
+- `subdomain`: Only SubdomainMiddleware is active (legacy behavior).
+- `both`: Both are active. PathRouting takes precedence; SubdomainMiddleware is fallback for requests that arrive via wildcard DNS.
+
+### Phase 3: URL Builder Update
+
+Update `url_builder.py` to generate path-based URLs:
+
+```python
+# ROUTING_MODE=path (new default)
+create_url("acme")  → "https://api.mcpworks.io/mcp/create/acme"
+run_url("acme")     → "https://api.mcpworks.io/mcp/run/acme"
+agent_url("mybot")  → "https://api.mcpworks.io/mcp/agent/mybot"
+mcp_url("acme")     → "https://api.mcpworks.io/mcp/run/acme"
+
+# ROUTING_MODE=subdomain (backward compat)
+create_url("acme")  → "https://acme.create.mcpworks.io"
+run_url("acme")     → "https://acme.run.mcpworks.io"
+```
+
+### Phase 4: MCPTransportMiddleware Update
+
+Currently intercepts requests where `path == "/mcp"`. Must be updated to intercept:
+
+- `/mcp/create/{ns}` (exact: 3 segments)
+- `/mcp/run/{ns}` (exact: 3 segments)
+- `/mcp/agent/{ns}` (exact: 3 segments)
+
+But NOT:
+- `/mcp/agent/{ns}/webhook/*` (these go to the webhook router)
+- `/mcp/agent/{ns}/chat/*` (these go to the chat router)
+- `/mcp/agent/{ns}/view/*` (these go to the scratchpad router)
+
+The middleware can check: path starts with `/mcp/` AND has exactly 3 segments AND segment[1] is in `{create, run, agent}` AND there's no 4th segment (no sub-path).
+
+### Phase 5: Agent Sub-Route Migration
+
+Agent-specific routes currently mounted as:
+- `webhooks.py` — matches `*/webhook/{path:path}` (relies on subdomain for namespace)
+- `public_chat.py` — matches `*/chat/{token}` (relies on subdomain for namespace)
+- `scratchpad_view.py` — matches `*/view/{token}/` (relies on subdomain for namespace)
+
+These need dual mounting:
+1. Under `/mcp/agent/{namespace}/webhook/...`, `/mcp/agent/{namespace}/chat/...`, `/mcp/agent/{namespace}/view/...` (path-based)
+2. Keep existing routes for subdomain fallback (when `ROUTING_MODE=both|subdomain`)
+
+### Phase 6: Documentation & Cleanup
+
+- Update quickstart HTML
+- Update tool descriptions in `tool_registry.py`
+- Update CLAUDE.md and SPEC.md
+- Update Caddy config documentation
+- Add deprecation header to subdomain responses
+- Update onboarding/console static pages
+
+## Data Model Changes
+
+None. This is a routing-only change. No database migrations required.
+
+## API Contract Changes
+
+### New Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/mcp/{endpoint}/{namespace}` | MCP JSON-RPC (create/run/agent) |
+| GET | `/mcp/{endpoint}/{namespace}` | MCP SSE reconnection |
+| DELETE | `/mcp/{endpoint}/{namespace}` | MCP session termination |
+| POST | `/mcp/agent/{namespace}/webhook/{path:path}` | Agent webhook ingress |
+| POST | `/mcp/agent/{namespace}/chat/{token}` | Agent public chat |
+| GET | `/mcp/agent/{namespace}/view/{token}/` | Agent scratchpad view |
+| GET | `/mcp` | MCP discovery |
+
+### Deprecated Endpoints (transition period)
+
+All subdomain-based access (`{ns}.{endpoint}.{domain}/mcp`, etc.) continues to work but returns `X-MCPWorks-Deprecated: subdomain-routing` header.
+
+## File Change Map
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `middleware/routing.py` | **NEW** | Path-based routing middleware |
+| `middleware/subdomain.py` | MODIFY | Add deprecation header; conditionally disabled |
+| `middleware/__init__.py` | MODIFY | Export new middleware |
+| `main.py` | MODIFY | Swap middleware based on `ROUTING_MODE` config |
+| `config.py` | MODIFY | Add `routing_mode` setting |
+| `url_builder.py` | MODIFY | Path-based URL generation |
+| `mcp/transport.py` | MODIFY | Match `/mcp/{endpoint}/{ns}` paths |
+| `api/v1/webhooks.py` | MODIFY | Support path-based namespace extraction |
+| `api/v1/public_chat.py` | MODIFY | Support path-based namespace extraction |
+| `api/v1/scratchpad_view.py` | MODIFY | Support path-based namespace extraction |
+| `api/v1/health.py` | MODIFY | Remove wildcard DNS validation endpoint (or keep for transition) |
+| `api/v1/quickstart.py` | MODIFY | Update URL examples |
+| `mcp/tool_registry.py` | MODIFY | Update tool descriptions with path-based URLs |
+| `mcp/router.py` | MODIFY | Update error messages |
+| `static/console.html` | MODIFY | Update displayed URLs |
+| `static/dashboard.html` | MODIFY | Update displayed URLs |
+| `CLAUDE.md` | MODIFY | Update architecture docs |
+| `SPEC.md` | MODIFY | Update endpoint docs |
+
+## Testing Strategy
+
+### Unit Tests
+
+- `test_routing_middleware.py` — path parsing, edge cases (invalid endpoint, missing namespace, special chars)
+- `test_url_builder.py` — URL generation for both routing modes
+
+### Integration Tests
+
+- Full MCP flow via path-based URL (initialize → tools/list → tools/call)
+- Agent webhook delivery via path-based URL
+- Agent chat via path-based URL
+- Billing middleware correctly identifies `run` endpoint via path
+
+### Backward Compatibility Tests
+
+- Subdomain routing still works when `ROUTING_MODE=both`
+- Deprecation header present on subdomain responses
+
+## Rollback Plan
+
+Set `ROUTING_MODE=subdomain` in environment. The entire path-based routing is bypassed. SubdomainMiddleware takes over exactly as before.
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| MCPTransportMiddleware path matching breaks | Medium | High | Careful regex/prefix matching; comprehensive tests |
+| Agent sub-routes don't mount correctly | Low | Medium | Test each route independently |
+| URL builder returns wrong format | Low | Medium | Config-driven with tests for both modes |
+| Existing users break during transition | Low | Low | `ROUTING_MODE=both` as intermediate step |
+
+## Plan Completeness Checklist
+
+- [x] All spec requirements mapped to technical approach
+- [x] Architecture described
+- [x] No database schema changes needed
+- [x] API contracts defined
+- [x] Error handling strategy documented (same as current — request.state contract unchanged)
+- [x] Testing strategy defined
+- [x] Rollback procedure defined
+- [x] Security review completed (path traversal mitigated by namespace validation)
+- [x] Token efficiency analysis completed (no impact)

--- a/specs/015-path-based-routing/spec.md
+++ b/specs/015-path-based-routing/spec.md
@@ -1,0 +1,224 @@
+# Feature Specification: Path-Based Routing
+
+**Feature Branch**: `015-path-based-routing`
+**Created**: 2026-03-30
+**Status**: Draft
+**Input**: Architecture change — move from subdomain-based namespace routing (`{ns}.{endpoint}.mcpworks.io`) to path-based routing (`api.mcpworks.io/mcp/{endpoint}/{namespace}`)
+
+## Motivation
+
+The current architecture requires wildcard DNS records and wildcard TLS certificates for every endpoint type (`*.create.mcpworks.io`, `*.run.mcpworks.io`, `*.agent.mcpworks.io`). This is a hard requirement for self-hosters because:
+
+1. **DNS complexity** — wildcard DNS requires control over a domain's DNS zone; local installs have no domain at all
+2. **TLS complexity** — wildcard certs require DNS-01 ACME challenges, which need API credentials for the DNS provider
+3. **Local development friction** — developers currently need query parameters (`?namespace=acme&endpoint=create`) as a workaround on localhost
+4. **Network restrictions** — corporate firewalls and NATs often block or complicate wildcard subdomain resolution
+
+Path-based routing eliminates all of this. A self-hoster runs `docker compose up` and connects at `http://localhost:8000/mcp/create/myns` — no DNS, no certs, no workarounds.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Self-Hosted MCP Connection (Priority: P1)
+
+A developer self-hosting MCPWorks on their local machine or LAN server configures their AI assistant (Claude Code, Cursor, etc.) to connect to a namespace via a single HTTP URL with no DNS or TLS configuration.
+
+**Independent Test**: Start the API on localhost:8000. Configure an MCP client to connect to `http://localhost:8000/mcp/create/testns`. Verify the client can initialize, list tools, and call tools against the `testns` namespace.
+
+**Acceptance Scenarios**:
+
+1. **Given** the API is running at `localhost:8000`, **When** a client POSTs a JSON-RPC `initialize` request to `/mcp/create/testns`, **Then** the server responds with MCP capabilities for the `testns` namespace in create mode.
+2. **Given** the API is running at `localhost:8000`, **When** a client POSTs a `tools/call` request to `/mcp/run/testns`, **Then** the function executes in the `testns` namespace sandbox.
+3. **Given** a self-hoster has no domain name, **When** they configure their MCP client URL to `http://192.168.1.50:8000/mcp/create/myns`, **Then** it works identically to the cloud version.
+
+---
+
+### User Story 2 - Cloud MCP Connection (Priority: P1)
+
+A cloud user connects to MCPWorks Cloud at `api.mcpworks.io`. The path-based URLs work identically to the self-hosted version.
+
+**Independent Test**: Configure an MCP client to connect to `https://api.mcpworks.io/mcp/run/acme`. Verify the client can initialize and execute functions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the API is deployed at `api.mcpworks.io`, **When** a client POSTs to `/mcp/create/acme`, **Then** the server responds with MCP capabilities for the `acme` namespace.
+2. **Given** the API is deployed at `api.mcpworks.io`, **When** a client POSTs to `/mcp/run/acme`, **Then** the function executes in the `acme` namespace.
+3. **Given** the API is deployed at `api.mcpworks.io`, **When** a client POSTs to `/mcp/agent/mybot`, **Then** the server responds in agent mode for the `mybot` namespace.
+
+---
+
+### User Story 3 - Backward Compatibility (Priority: P2)
+
+Existing users who have configured their MCP clients using the subdomain URLs (`acme.create.mcpworks.io`) continue to work during a transition period. The subdomain middleware remains functional but is no longer the primary routing mechanism.
+
+**Independent Test**: With the API running behind the existing Caddy config, verify that a request to `acme.create.mcpworks.io/mcp` still routes correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a client configured with `acme.create.mcpworks.io/mcp`, **When** the client sends requests, **Then** they are handled identically to `/mcp/create/acme`.
+2. **Given** subdomain-based routing is used, **When** the server responds, **Then** a deprecation header (`X-MCPWorks-Deprecated: subdomain-routing`) is included in the response.
+
+---
+
+### User Story 4 - Agent Webhooks via Path (Priority: P1)
+
+Agent webhooks currently rely on `{agent}.agent.mcpworks.io/webhook/{path}`. These must work via path-based routing as well.
+
+**Independent Test**: Send a POST to `/mcp/agent/mybot/webhook/github/push` with a webhook payload. Verify the agent receives and processes it.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent `mybot` with a webhook configured for `github/push`, **When** a POST is sent to `/mcp/agent/mybot/webhook/github/push`, **Then** the webhook is processed.
+2. **Given** an agent `mybot` with a public chat token, **When** a POST is sent to `/mcp/agent/mybot/chat/{token}`, **Then** the chat message is processed.
+3. **Given** an agent `mybot` with a scratchpad view token, **When** a GET is sent to `/mcp/agent/mybot/view/{token}/`, **Then** the scratchpad HTML is served.
+
+---
+
+### Edge Cases
+
+- **Namespace with slashes or special chars**: Namespace names are already validated as `[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?` — no change needed. FastAPI path parameter captures the segment between slashes.
+- **Trailing slashes**: `/mcp/create/acme` and `/mcp/create/acme/` should both work (FastAPI's `redirect_slashes` handles this).
+- **Invalid endpoint type**: `/mcp/invalid/acme` returns 404 with a clear error message listing valid types.
+- **Missing namespace**: `/mcp/create/` or `/mcp/create` returns 404.
+- **Root MCP path**: `GET /mcp` returns discovery info (protocol version, supported endpoints).
+- **SSE transport**: The MCP Streamable HTTP transport at `/mcp/{endpoint}/{namespace}` must support both POST (JSON-RPC) and GET (SSE stream reconnection) per the MCP spec.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Path-Based MCP Routing:**
+
+- **FR-001**: The API MUST accept MCP requests at `/mcp/{endpoint}/{namespace}` where `endpoint` is one of `create`, `run`, or `agent`.
+  - Priority: P1
+  - Acceptance: MCP clients can connect using path-based URLs for all three endpoint types.
+
+- **FR-002**: The path parameters MUST populate `request.state.namespace` and `request.state.endpoint_type` identically to how `SubdomainMiddleware` does today, so downstream handlers require zero changes.
+  - Priority: P1
+  - Acceptance: `mcp/transport.py`, `mcp/router.py`, `middleware/billing.py`, and all other consumers of `request.state` work without modification.
+
+- **FR-003**: The `url_builder` module MUST generate path-based URLs by default, with a config toggle (`ROUTING_MODE=path|subdomain`) for backward compatibility.
+  - Priority: P1
+  - Acceptance: `url_builder.create_url("acme")` returns `https://api.mcpworks.io/mcp/create/acme` when `ROUTING_MODE=path`.
+
+- **FR-004**: Agent sub-paths (webhooks, chat, scratchpad view) MUST work under the path-based scheme: `/mcp/agent/{namespace}/webhook/{path}`, `/mcp/agent/{namespace}/chat/{token}`, `/mcp/agent/{namespace}/view/{token}/`.
+  - Priority: P1
+  - Acceptance: All existing agent webhook, chat, and view functionality works via path-based URLs.
+
+- **FR-005**: The existing `SubdomainMiddleware` MUST remain functional for backward compatibility during a transition period. It can be disabled via `ROUTING_MODE=path`.
+  - Priority: P2
+  - Acceptance: Setting `ROUTING_MODE=subdomain` preserves current behavior exactly.
+
+**URL Generation:**
+
+- **FR-006**: All URLs returned in API responses, tool descriptions, quickstart docs, and onboarding flows MUST use the path-based format when `ROUTING_MODE=path`.
+  - Priority: P1
+  - Acceptance: No subdomain-pattern URLs appear in any response when routing mode is `path`.
+
+**Discovery:**
+
+- **FR-007**: `GET /mcp` MUST return protocol discovery info including available endpoint types and URL patterns.
+  - Priority: P2
+  - Acceptance: Clients can discover the URL pattern from the root MCP endpoint.
+
+### Non-Functional Requirements
+
+**NFR-001: Zero Performance Regression**
+- Path-based routing MUST NOT add measurable latency vs. subdomain routing. Both are O(1) string operations — path param extraction vs. regex match.
+
+**NFR-002: Self-Host Simplicity**
+- A self-hoster MUST be able to connect with just an IP address and port. No DNS, no TLS, no domain name required.
+
+**NFR-003: Single Origin**
+- All MCP traffic MUST be servable from a single origin (`api.mcpworks.io` for cloud, `localhost:8000` for local). This eliminates wildcard CORS, wildcard DNS, and wildcard TLS requirements.
+
+## Infrastructure Impact
+
+### Caddy Configuration (Cloud)
+
+**Before:**
+```
+*.create.mcpworks.io, *.run.mcpworks.io, *.agent.mcpworks.io {
+    tls { dns cloudflare ... }
+    reverse_proxy server0:8000
+}
+```
+
+**After:**
+```
+api.mcpworks.io {
+    reverse_proxy server0:8000
+}
+# Keep wildcard block during transition (can be removed later)
+```
+
+### DNS (Cloud)
+
+**Before:** Three wildcard A records (`*.create`, `*.run`, `*.agent`)
+**After:** Single A record (`api`) — wildcards can be removed after transition period
+
+### Self-Hosted docker-compose
+
+No Caddy needed for local. Just the API container on port 8000. MCP clients connect directly to `http://localhost:8000/mcp/create/myns`.
+
+## Constraints & Assumptions
+
+### Technical Constraints
+
+- The MCP Streamable HTTP transport middleware (`MCPTransportMiddleware`) currently intercepts `/mcp` requests. It must be updated to intercept `/mcp/{endpoint}/{namespace}` instead.
+- FastAPI path parameters handle URL decoding automatically.
+- The agent webhook, chat, and view routes currently live in separate router files (`webhooks.py`, `public_chat.py`, `scratchpad_view.py`) and rely on subdomain middleware for namespace extraction. These must also support path-based extraction.
+
+### Assumptions
+
+- MCP clients (Claude Code, Cursor, etc.) connect to a single URL — they don't need to resolve different subdomains for create vs. run. Confirmed: MCP clients use a single `url` field.
+- The transition period for subdomain support is 90 days from deployment.
+- No existing self-hosters are using subdomain routing (the feature hasn't been released yet in self-hosted mode).
+
+## Security Analysis
+
+### Threat: Namespace Enumeration via Path
+
+**Impact**: Low — namespace names are not secret (they're visible in DNS today)
+**Mitigation**: Same auth enforcement. API key is still required for all MCP operations.
+
+### Threat: Path Traversal
+
+**Impact**: Medium — malicious namespace like `../../admin`
+**Mitigation**: FastAPI path parameters are URL-decoded but do not traverse directories. Additionally, the existing namespace validation regex (`[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?`) rejects any traversal attempts.
+
+## Token Efficiency Analysis
+
+No impact. URL routing is infrastructure — it doesn't affect MCP response payloads.
+
+## Observability
+
+- **Metric**: Existing `mcpworks_mcp_tool_calls_total` continues to work (labels from `request.state`, unchanged).
+- **Logging**: Request logging middleware already logs namespace and endpoint_type from `request.state`.
+- **New metric**: `mcpworks_routing_mode_requests_total{mode="path|subdomain"}` to track migration progress.
+
+## Spec Completeness Checklist
+
+- [x] Clear user value proposition stated
+- [x] Success criteria defined and measurable
+- [x] All functional requirements enumerated
+- [x] All constraints documented
+- [x] Error scenarios identified
+- [x] Security requirements specified
+- [x] Performance requirements quantified
+- [x] Token efficiency requirements stated
+- [x] Testing requirements defined
+- [x] Observability requirements defined
+
+## Approval
+
+**Status:** Draft
+
+**Approvals:**
+- [ ] CTO (Simon Carr)
+
+---
+
+## Changelog
+
+**v0.1.0 (2026-03-30):**
+- Initial draft

--- a/specs/015-path-based-routing/tasks.md
+++ b/specs/015-path-based-routing/tasks.md
@@ -1,0 +1,223 @@
+# Tasks: Path-Based Routing
+
+**Spec**: [spec.md](spec.md)
+**Plan**: [plan.md](plan.md)
+**Created**: 2026-03-30
+
+## Task 1: Add `routing_mode` config setting
+
+**Estimated Effort**: 1 hour
+**Dependencies**: None
+
+### Acceptance Criteria
+- [ ] `Settings.routing_mode` field added with type `Literal["path", "subdomain", "both"]`, default `"path"`
+- [ ] `ROUTING_MODE` env var controls the setting
+- [ ] Setting is accessible via `get_settings().routing_mode`
+
+### Files
+- `src/mcpworks_api/config.py`
+
+---
+
+## Task 2: Create `PathRoutingMiddleware`
+
+**Estimated Effort**: 3 hours
+**Dependencies**: Task 1
+
+### Acceptance Criteria
+- [ ] New file `middleware/routing.py` with `PathRoutingMiddleware`
+- [ ] Parses `/mcp/{endpoint}/{namespace}` from request path
+- [ ] Sets `request.state.namespace`, `request.state.endpoint_type`, `request.state.is_local`
+- [ ] Validates endpoint is one of `create`, `run`, `agent`
+- [ ] Validates namespace matches `[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?`
+- [ ] Passes through requests that don't match `/mcp/*` (health, v1 API, static pages)
+- [ ] Returns 404 for `/mcp/{invalid_endpoint}/{ns}`
+- [ ] Returns 404 for `/mcp/{endpoint}/` (missing namespace)
+- [ ] Agent sub-paths (`/mcp/agent/{ns}/webhook/*`, `/mcp/agent/{ns}/chat/*`, `/mcp/agent/{ns}/view/*`) set request.state but do NOT rewrite the path — they pass through to agent-specific routers
+- [ ] `GET /mcp` passes through (discovery endpoint)
+- [ ] Exported from `middleware/__init__.py`
+
+### Files
+- `src/mcpworks_api/middleware/routing.py` (new)
+- `src/mcpworks_api/middleware/__init__.py`
+
+---
+
+## Task 3: Update `MCPTransportMiddleware` path matching
+
+**Estimated Effort**: 2 hours
+**Dependencies**: Task 2
+
+### Acceptance Criteria
+- [ ] `MCPTransportMiddleware` intercepts POST/GET/DELETE to `/mcp/{endpoint}/{namespace}` (3 path segments under /mcp/)
+- [ ] Does NOT intercept agent sub-paths with 4+ segments (`/mcp/agent/{ns}/webhook/*`, etc.)
+- [ ] Does NOT intercept `GET /mcp` (discovery)
+- [ ] SSE reconnection (GET) works at `/mcp/{endpoint}/{namespace}`
+- [ ] Session termination (DELETE) works at `/mcp/{endpoint}/{namespace}`
+- [ ] Backward compat: still intercepts `/mcp` when `ROUTING_MODE=subdomain|both`
+
+### Files
+- `src/mcpworks_api/mcp/transport.py`
+
+---
+
+## Task 4: Update `url_builder.py`
+
+**Estimated Effort**: 1.5 hours
+**Dependencies**: Task 1
+
+### Acceptance Criteria
+- [ ] When `routing_mode == "path"`: `create_url("acme")` returns `https://api.mcpworks.io/mcp/create/acme`
+- [ ] When `routing_mode == "path"`: `run_url("acme")` returns `https://api.mcpworks.io/mcp/run/acme`
+- [ ] When `routing_mode == "path"`: `agent_url("mybot")` returns `https://api.mcpworks.io/mcp/agent/mybot`
+- [ ] When `routing_mode == "path"`: `mcp_url("acme", "run")` returns `https://api.mcpworks.io/mcp/run/acme`
+- [ ] When `routing_mode == "path"`: `view_url("mybot", "tok123")` returns `https://api.mcpworks.io/mcp/agent/mybot/view/tok123/`
+- [ ] When `routing_mode == "path"`: `chat_url("mybot", "tok123")` returns `https://api.mcpworks.io/mcp/agent/mybot/chat/tok123`
+- [ ] When `routing_mode == "subdomain"`: all functions return current subdomain-based URLs (no regression)
+- [ ] `valid_suffixes()` updated or replaced with a path-aware equivalent
+
+### Files
+- `src/mcpworks_api/url_builder.py`
+
+---
+
+## Task 5: Wire middleware in `main.py`
+
+**Estimated Effort**: 1 hour
+**Dependencies**: Task 2
+
+### Acceptance Criteria
+- [ ] When `ROUTING_MODE=path`: `PathRoutingMiddleware` is added, `SubdomainMiddleware` is NOT added
+- [ ] When `ROUTING_MODE=subdomain`: `SubdomainMiddleware` is added, `PathRoutingMiddleware` is NOT added
+- [ ] When `ROUTING_MODE=both`: Both middlewares are added; `PathRoutingMiddleware` runs first (added last in FastAPI middleware stack) and only populates `request.state` if the path matches; `SubdomainMiddleware` fills in if path didn't match
+- [ ] Middleware ordering preserved: Correlation → Logging → Routing → Rate Limit → Billing → Transport (innermost)
+
+### Files
+- `src/mcpworks_api/main.py`
+
+---
+
+## Task 6: Mount agent sub-routes under path-based prefix
+
+**Estimated Effort**: 2 hours
+**Dependencies**: Task 2
+
+### Acceptance Criteria
+- [ ] Webhook ingress works at `POST /mcp/agent/{namespace}/webhook/{path:path}`
+- [ ] Public chat works at `POST /mcp/agent/{namespace}/chat/{token}`
+- [ ] Scratchpad view works at `GET /mcp/agent/{namespace}/view/{token}/`
+- [ ] Each handler extracts namespace from the path parameter (or from `request.state` set by middleware)
+- [ ] Existing subdomain-based routes preserved when `ROUTING_MODE=subdomain|both`
+
+### Files
+- `src/mcpworks_api/api/v1/webhooks.py`
+- `src/mcpworks_api/api/v1/public_chat.py`
+- `src/mcpworks_api/api/v1/scratchpad_view.py`
+- `src/mcpworks_api/main.py` (router mounting)
+
+---
+
+## Task 7: Update tool descriptions and quickstart docs
+
+**Estimated Effort**: 1.5 hours
+**Dependencies**: Task 4
+
+### Acceptance Criteria
+- [ ] `tool_registry.py` webhook/chat URL descriptions use `url_builder` (not hardcoded subdomain patterns)
+- [ ] `quickstart.py` HTML updated to show path-based URL examples
+- [ ] Error messages in `mcp/router.py` updated to reference path-based format
+
+### Files
+- `src/mcpworks_api/mcp/tool_registry.py`
+- `src/mcpworks_api/api/v1/quickstart.py`
+- `src/mcpworks_api/mcp/router.py`
+
+---
+
+## Task 8: Add deprecation header to subdomain responses
+
+**Estimated Effort**: 0.5 hours
+**Dependencies**: Task 2
+
+### Acceptance Criteria
+- [ ] When `SubdomainMiddleware` handles a request (i.e., namespace was extracted from subdomain, not path), the response includes `X-MCPWorks-Deprecated: subdomain-routing; migrate to /mcp/{endpoint}/{namespace}`
+- [ ] Header is NOT added when `ROUTING_MODE=subdomain` (no deprecation when it's the only mode)
+
+### Files
+- `src/mcpworks_api/middleware/subdomain.py`
+
+---
+
+## Task 9: Add MCP discovery endpoint
+
+**Estimated Effort**: 0.5 hours
+**Dependencies**: Task 4
+
+### Acceptance Criteria
+- [ ] `GET /mcp` returns JSON with protocol version, supported endpoint types, and URL pattern template
+- [ ] Response example: `{"protocol": "mcp", "version": "2024-11-05", "url_template": "/mcp/{endpoint}/{namespace}", "endpoints": ["create", "run", "agent"]}`
+
+### Files
+- `src/mcpworks_api/mcp/router.py` or new route in `main.py`
+
+---
+
+## Task 10: Write tests
+
+**Estimated Effort**: 3 hours
+**Dependencies**: Tasks 1-6
+
+### Acceptance Criteria
+- [ ] Unit tests for `PathRoutingMiddleware` — valid paths, invalid paths, edge cases
+- [ ] Unit tests for `url_builder` — both routing modes
+- [ ] Integration test: full MCP create flow via `/mcp/create/{ns}`
+- [ ] Integration test: full MCP run flow via `/mcp/run/{ns}`
+- [ ] Integration test: agent webhook via `/mcp/agent/{ns}/webhook/{path}`
+- [ ] Integration test: billing middleware fires on `/mcp/run/{ns}` (endpoint_type == "run")
+- [ ] Backward compat test: subdomain routing when `ROUTING_MODE=both`
+
+### Files
+- `tests/unit/test_routing_middleware.py` (new)
+- `tests/unit/test_url_builder.py` (new or update)
+- `tests/integration/test_path_routing.py` (new)
+
+---
+
+## Task 11: Update project documentation
+
+**Estimated Effort**: 1 hour
+**Dependencies**: Tasks 1-9
+
+### Acceptance Criteria
+- [ ] `CLAUDE.md` updated: architecture section reflects path-based routing as primary
+- [ ] `SPEC.md` updated if it references subdomain patterns
+- [ ] `CLAUDE.md` endpoint pattern changed from `{ns}.create.mcpworks.io` to `api.mcpworks.io/mcp/create/{ns}`
+- [ ] Static HTML pages (console, dashboard, onboarding) updated if they display URLs
+
+### Files
+- `CLAUDE.md`
+- `SPEC.md`
+- `src/mcpworks_api/static/console.html`
+- `src/mcpworks_api/static/dashboard.html`
+
+---
+
+## Execution Order
+
+```
+Task 1 (config)
+  ├── Task 2 (PathRoutingMiddleware)
+  │     ├── Task 3 (transport middleware update)
+  │     ├── Task 5 (wire in main.py)
+  │     ├── Task 6 (agent sub-routes)
+  │     └── Task 8 (deprecation header)
+  ├── Task 4 (url_builder)
+  │     ├── Task 7 (tool descriptions & docs)
+  │     └── Task 9 (discovery endpoint)
+  └── Task 10 (tests — after 1-6)
+       └── Task 11 (documentation — after all)
+```
+
+**Critical path**: Task 1 → Task 2 → Task 3 → Task 5 → Task 10
+
+**Estimated total effort**: ~17 hours

--- a/src/mcpworks_api/api/v1/agent_path_routes.py
+++ b/src/mcpworks_api/api/v1/agent_path_routes.py
@@ -1,0 +1,56 @@
+"""Path-based agent sub-routes for 015-path-based-routing.
+
+Mounts webhook, chat, and scratchpad view handlers under
+/mcp/agent/{namespace}/... for path-based routing mode.
+"""
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, Response
+
+router = APIRouter(prefix="/mcp/agent/{namespace}", tags=["agent-path"])
+
+
+@router.post("/webhook/{path:path}")
+async def webhook_path(namespace: str, path: str, request: Request) -> JSONResponse:
+    from mcpworks_api.api.v1.webhooks import handle_agent_webhook
+
+    request.state.namespace = namespace
+    return await handle_agent_webhook(path, request)
+
+
+@router.options("/chat/{token}")
+async def chat_preflight_path(namespace: str, token: str, request: Request) -> JSONResponse:
+    from mcpworks_api.api.v1.public_chat import chat_preflight
+
+    request.state.namespace = namespace
+    return await chat_preflight(token, request)
+
+
+@router.post("/chat/{token}")
+async def chat_path(namespace: str, token: str, request: Request) -> JSONResponse:
+    from mcpworks_api.api.v1.public_chat import public_chat
+
+    request.state.namespace = namespace
+    return await public_chat(token, request)
+
+
+@router.get("/view/{token}/{path:path}")
+@router.get("/view/{token}/")
+async def view_path(
+    namespace: str,
+    token: str,
+    request: Request,
+    path: str = "index.html",
+) -> Response:
+    from mcpworks_api.api.v1.scratchpad_view import serve_scratchpad
+
+    request.state.namespace = namespace
+    return await serve_scratchpad(token, request, path)
+
+
+@router.post("/view/{token}/chat")
+async def view_chat_path(namespace: str, token: str, request: Request) -> Response:
+    from mcpworks_api.api.v1.scratchpad_view import scratchpad_chat
+
+    request.state.namespace = namespace
+    return await scratchpad_chat(token, request)

--- a/src/mcpworks_api/api/v1/public_chat.py
+++ b/src/mcpworks_api/api/v1/public_chat.py
@@ -1,6 +1,6 @@
 """Public chat endpoint for agents via obfuscated URL token.
 
-URL: POST https://{agent}.agent.{BASE_DOMAIN}/chat/{token}
+URL: POST /mcp/agent/{agent}/chat/{token}
 The token in the URL IS the authentication.
 """
 

--- a/src/mcpworks_api/api/v1/quickstart.py
+++ b/src/mcpworks_api/api/v1/quickstart.py
@@ -139,8 +139,8 @@ It requires OPENAI_API_KEY."</code></pre>
 
 <h2>What's Happening Behind the Scenes</h2>
 <ul>
-<li><strong>create endpoint</strong> (<code>*.create.{{BASE_DOMAIN}}</code>) — manages your namespaces, services, and functions</li>
-<li><strong>run endpoint</strong> (<code>*.run.{{BASE_DOMAIN}}</code>) — executes functions in a secure nsjail sandbox</li>
+<li><strong>create endpoint</strong> (<code>/mcp/create/{{namespace}}</code>) — manages your namespaces, services, and functions</li>
+<li><strong>run endpoint</strong> (<code>/mcp/run/{{namespace}}</code>) — executes functions in a secure nsjail sandbox</li>
 <li>Each function runs in an isolated container with no network access to your database or secrets</li>
 <li>60+ Python packages pre-installed (numpy, pandas, httpx, etc.) — use <code>list_packages</code> to see all</li>
 <li>Environment variables are passed per-request via header — never stored server-side</li>

--- a/src/mcpworks_api/api/v1/scratchpad_view.py
+++ b/src/mcpworks_api/api/v1/scratchpad_view.py
@@ -1,4 +1,4 @@
-"""Public scratchpad view serving for *.agent.{BASE_DOMAIN}/view/{token}/."""
+"""Public scratchpad view serving for /mcp/agent/{ns}/view/{token}/."""
 
 from pathlib import PurePosixPath
 
@@ -88,7 +88,13 @@ async def serve_scratchpad(
         host = request.headers.get("host", "").lower()
         is_local = getattr(request.state, "is_local", False)
         if not is_local:
-            expected_host = url_builder.agent_url(agent.name).split("://", 1)[1]
+            from mcpworks_api.config import get_settings
+
+            settings = get_settings()
+            if settings.routing_mode in ("path", "both"):
+                expected_host = f"api.{settings.base_domain}"
+            else:
+                expected_host = url_builder.agent_url(agent.name).split("://", 1)[1]
             if not host.startswith(expected_host):
                 return NOT_FOUND
 

--- a/src/mcpworks_api/api/v1/webhooks.py
+++ b/src/mcpworks_api/api/v1/webhooks.py
@@ -1,4 +1,4 @@
-"""Webhook ingress handler for *.agent.{BASE_DOMAIN}/webhook/* requests."""
+"""Webhook ingress handler for /mcp/agent/{ns}/webhook/* requests."""
 
 import hashlib
 import hmac
@@ -27,7 +27,7 @@ router = APIRouter(tags=["webhooks"])
 async def handle_agent_webhook(path: str, request: Request) -> JSONResponse:
     """Handle incoming webhook for agent endpoints.
 
-    URL: https://{agent-name}.agent.{BASE_DOMAIN}/webhook/{path}
+    URL: /mcp/agent/{agent-name}/webhook/{path}
     """
     namespace = getattr(request.state, "namespace", None)
     if not namespace:

--- a/src/mcpworks_api/config.py
+++ b/src/mcpworks_api/config.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
         default="https",
         description="URL scheme for generated URLs (https or http)",
     )
+    routing_mode: Literal["path", "subdomain", "both"] = Field(
+        default="path",
+        description="URL routing: path (/mcp/create/ns), subdomain (ns.create.domain), or both",
+    )
     allow_registration: bool = Field(
         default=False,
         description="Whether public user registration is enabled",

--- a/src/mcpworks_api/main.py
+++ b/src/mcpworks_api/main.py
@@ -23,6 +23,7 @@ from mcpworks_api.mcp.transport import MCPTransportMiddleware, session_manager
 from mcpworks_api.middleware import (
     BillingMiddleware,
     CorrelationIdMiddleware,
+    PathRoutingMiddleware,
     RequestLoggingMiddleware,
     SubdomainMiddleware,
     register_exception_handlers,
@@ -200,8 +201,12 @@ def create_app() -> FastAPI:
     # Rate limiting middleware
     app.add_middleware(RateLimitMiddleware)
 
-    # Subdomain parsing (A0: namespace + endpoint type extraction)
-    app.add_middleware(SubdomainMiddleware)
+    # Namespace + endpoint type extraction (015: path-based or subdomain)
+    routing_mode = settings.routing_mode
+    if routing_mode in ("path", "both"):
+        app.add_middleware(PathRoutingMiddleware)
+    if routing_mode in ("subdomain", "both"):
+        app.add_middleware(SubdomainMiddleware)
 
     # ORDER-021: Structured per-request logging (runs after correlation ID is set)
     app.add_middleware(RequestLoggingMiddleware)
@@ -234,6 +239,11 @@ def create_app() -> FastAPI:
     app.include_router(public_chat_router)
     app.include_router(mcp_proxy_router)
 
+    # 015: Path-based agent sub-routes (/mcp/agent/{ns}/webhook, /chat, /view)
+    from mcpworks_api.api.v1.agent_path_routes import router as agent_path_router
+
+    app.include_router(agent_path_router)
+
     # Setup Prometheus metrics (after routers so routes are available)
     if settings.prometheus_enabled:
         setup_metrics(app)
@@ -246,6 +256,18 @@ def create_app() -> FastAPI:
             "name": "mcpworks API",
             "version": "0.1.0",
             "docs": "/docs" if settings.app_debug else "disabled",
+        }
+
+    # MCP protocol discovery
+    @app.get("/mcp")
+    async def mcp_discovery() -> dict:
+        """MCP protocol discovery endpoint."""
+        return {
+            "protocol": "mcp",
+            "version": "2024-11-05",
+            "url_template": "/mcp/{endpoint}/{namespace}",
+            "endpoints": ["create", "run", "agent"],
+            "docs": "/docs/quickstart",
         }
 
     # OAuth Protected Resource metadata (RFC 9728)

--- a/src/mcpworks_api/mcp/create_handler.py
+++ b/src/mcpworks_api/mcp/create_handler.py
@@ -83,7 +83,7 @@ def _coerce_json_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
 
 
 class CreateMCPHandler:
-    """Handler for *.create.mcpworks.io endpoints.
+    """Handler for /mcp/create/{namespace} endpoints.
 
     Provides management operations for namespaces, services, and functions.
     """

--- a/src/mcpworks_api/mcp/router.py
+++ b/src/mcpworks_api/mcp/router.py
@@ -228,7 +228,7 @@ async def handle_mcp_request(
     if not namespace_name:
         return make_error_response(
             MCPErrorCodes.INVALID_REQUEST,
-            "Missing namespace. Use {namespace}.create.<domain> or {namespace}.run.<domain>",
+            "Missing namespace. Use /mcp/{create|run|agent}/{namespace}",
         ).model_dump()
 
     if endpoint_type not in ("create", "run", "agent"):

--- a/src/mcpworks_api/mcp/run_handler.py
+++ b/src/mcpworks_api/mcp/run_handler.py
@@ -37,7 +37,7 @@ logger = structlog.get_logger(__name__)
 
 
 class RunMCPHandler:
-    """Handler for *.run.mcpworks.io endpoints.
+    """Handler for /mcp/run/{namespace} endpoints.
 
     Provides function execution by:
     1. Dynamically generating tools from database functions

--- a/src/mcpworks_api/mcp/tool_registry.py
+++ b/src/mcpworks_api/mcp/tool_registry.py
@@ -717,7 +717,7 @@ AGENT_TOOLS: dict[str, ToolDef] = {
         description=(
             "Add a webhook endpoint to an agent. "
             "When the webhook URL receives an HTTP POST, it triggers the specified handler function. "
-            "The webhook URL will be: https://{agent_name}.agent.<domain>/webhook/{path}"
+            "The webhook URL will be: /mcp/agent/{agent_name}/webhook/{path}"
         ),
         input_schema={
             "type": "object",
@@ -728,7 +728,7 @@ AGENT_TOOLS: dict[str, ToolDef] = {
                 },
                 "path": {
                     "type": "string",
-                    "description": "Webhook path segment. Example: 'github/push' creates URL https://{agent}.agent.<domain>/webhook/github/push",
+                    "description": "Webhook path segment. Example: 'github/push' creates URL /mcp/agent/{agent}/webhook/github/push",
                 },
                 "handler_function_name": {
                     "type": "string",
@@ -1465,7 +1465,7 @@ AGENT_TOOLS: dict[str, ToolDef] = {
             "Generate or revoke a public chat URL for an agent. "
             "The URL allows web frontends to POST messages to the agent's AI "
             "without API key authentication — the token in the URL IS the auth. "
-            "Pattern: POST https://{agent}.agent.<domain>/chat/{token}"
+            "Pattern: POST /mcp/agent/{agent}/chat/{token}"
         ),
         input_schema={
             "type": "object",

--- a/src/mcpworks_api/mcp/transport.py
+++ b/src/mcpworks_api/mcp/transport.py
@@ -268,7 +268,7 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> list[TextCon
     endpoint_type = getattr(request.state, "endpoint_type", None)
     if not namespace or not endpoint_type:
         raise ValueError(
-            "Missing namespace or endpoint type. Use {namespace}.{create|run|agent}.<domain>"
+            "Missing namespace or endpoint type. Use /mcp/{create|run|agent}/{namespace}"
         )
 
     args = arguments or {}
@@ -320,26 +320,56 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> list[TextCon
 
 
 # ---------------------------------------------------------------------------
-# ASGI middleware – intercepts /mcp before Starlette routing (avoids 307 redirect)
+# ASGI middleware – intercepts MCP protocol requests before Starlette routing
 # ---------------------------------------------------------------------------
-class MCPTransportMiddleware:
-    """ASGI middleware that intercepts ``/mcp`` requests for MCP transport.
+_MCP_ENDPOINTS = frozenset({"create", "run", "agent"})
 
-    Added as the innermost middleware so that SubdomainMiddleware, RateLimit,
-    and Billing have already run.  Handles POST/GET/DELETE at ``/mcp``
-    directly via the SDK session manager, bypassing Starlette's ``Mount``
-    redirect from ``/mcp`` → ``/mcp/``.
+
+def _is_mcp_protocol_path(path: str, method: str = "") -> bool:
+    """Check if path is an MCP protocol endpoint (not an agent sub-route).
+
+    Matches:
+      /mcp, /mcp/                    — legacy subdomain mode (POST/DELETE only)
+      /mcp/{endpoint}/{namespace}    — path-based routing (3 segments under /mcp/)
+
+    Does NOT match:
+      GET /mcp                       — discovery endpoint (handled by FastAPI)
+      /mcp/agent/{ns}/webhook/...    — agent webhook (4+ segments)
+      /mcp/agent/{ns}/chat/...       — agent chat (4+ segments)
+      /mcp/agent/{ns}/view/...       — agent scratchpad (4+ segments)
+    """
+    if path in ("/mcp", "/mcp/"):
+        # Let GET /mcp fall through to discovery endpoint
+        if method.upper() == "GET":
+            return False
+        return True
+    if not path.startswith("/mcp/"):
+        return False
+    segments = path.rstrip("/").split("/")
+    # /mcp/{endpoint}/{namespace} → ["", "mcp", endpoint, namespace]
+    return len(segments) == 4 and segments[2] in _MCP_ENDPOINTS
+
+
+class MCPTransportMiddleware:
+    """ASGI middleware that intercepts MCP protocol requests.
+
+    Added as the innermost middleware so that routing, RateLimit,
+    and Billing have already run.  Handles POST/GET/DELETE at MCP
+    endpoints directly via the SDK session manager.
+
+    Supports both subdomain-mode (/mcp) and path-mode (/mcp/{endpoint}/{ns}).
     """
 
     def __init__(self, app: Any) -> None:
         self.app = app
 
     async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
-        if scope["type"] == "http" and scope.get("path", "") in ("/mcp", "/mcp/"):
+        if scope["type"] == "http" and _is_mcp_protocol_path(
+            scope.get("path", ""), scope.get("method", "")
+        ):
             request = Request(scope, receive, send)
             token = _current_request.set(request)
             try:
-                # Session manager expects root-relative path
                 inner_scope = dict(scope)
                 inner_scope["path"] = "/"
                 await session_manager.handle_request(inner_scope, receive, send)

--- a/src/mcpworks_api/middleware/__init__.py
+++ b/src/mcpworks_api/middleware/__init__.py
@@ -8,6 +8,7 @@ from mcpworks_api.middleware.billing import (
 from mcpworks_api.middleware.correlation import CorrelationIdMiddleware
 from mcpworks_api.middleware.error_handler import register_exception_handlers
 from mcpworks_api.middleware.request_logging import RequestLoggingMiddleware
+from mcpworks_api.middleware.routing import PathRoutingMiddleware
 from mcpworks_api.middleware.subdomain import (
     EndpointType,
     SubdomainMiddleware,
@@ -21,7 +22,9 @@ __all__ = [
     "CorrelationIdMiddleware",
     "RequestLoggingMiddleware",
     "register_exception_handlers",
-    # Subdomain middleware (A0)
+    # Path-based routing middleware (015)
+    "PathRoutingMiddleware",
+    # Subdomain middleware (A0, legacy)
     "SubdomainMiddleware",
     "EndpointType",
     "get_namespace",

--- a/src/mcpworks_api/middleware/routing.py
+++ b/src/mcpworks_api/middleware/routing.py
@@ -1,0 +1,77 @@
+"""Path-based routing middleware for namespace and endpoint type extraction.
+
+Parse URL path to extract namespace and endpoint type.
+
+Examples:
+  /mcp/create/acme → namespace="acme", endpoint="create"
+  /mcp/run/acme    → namespace="acme", endpoint="run"
+  /mcp/agent/mybot → namespace="acme", endpoint="agent"
+  /mcp/agent/mybot/webhook/github/push → namespace="mybot", endpoint="agent"
+"""
+
+import re
+
+from fastapi import HTTPException, Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+from mcpworks_api.middleware.subdomain import EndpointType
+
+_VALID_ENDPOINTS = frozenset({"create", "run", "agent"})
+_NAMESPACE_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+
+class PathRoutingMiddleware(BaseHTTPMiddleware):
+    """Extract namespace and endpoint type from URL path.
+
+    Matches paths like:
+      /mcp/{endpoint}/{namespace}         — MCP protocol (create/run/agent)
+      /mcp/agent/{namespace}/webhook/...  — agent webhook ingress
+      /mcp/agent/{namespace}/chat/...     — agent public chat
+      /mcp/agent/{namespace}/view/...     — agent scratchpad view
+
+    Sets the following on request.state:
+    - namespace: The namespace name (e.g., "acme")
+    - endpoint_type: The endpoint type ("create", "run", or "agent")
+    - is_local: Always False (path routing doesn't distinguish)
+
+    Passes through requests that don't start with /mcp/.
+    """
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        path = request.url.path
+
+        if not path.startswith("/mcp/"):
+            return await call_next(request)
+
+        segments = path.split("/")
+        # segments[0] = "", segments[1] = "mcp", segments[2] = endpoint, segments[3] = namespace, ...
+        if len(segments) < 4:
+            return await call_next(request)
+
+        endpoint = segments[2]
+        namespace = segments[3]
+
+        if endpoint not in _VALID_ENDPOINTS:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "code": "INVALID_ENDPOINT",
+                    "message": f"Invalid endpoint '{endpoint}'. Must be one of: create, run, agent",
+                },
+            )
+
+        if not namespace or not _NAMESPACE_RE.match(namespace):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "INVALID_NAMESPACE",
+                    "message": f"Invalid namespace '{namespace}'. Must match [a-z0-9]([a-z0-9-]{{0,61}}[a-z0-9])?",
+                },
+            )
+
+        request.state.namespace = namespace
+        request.state.endpoint_type = EndpointType(endpoint)
+        request.state.is_local = False
+
+        return await call_next(request)

--- a/src/mcpworks_api/middleware/subdomain.py
+++ b/src/mcpworks_api/middleware/subdomain.py
@@ -80,6 +80,10 @@ class SubdomainMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         """Process request and extract subdomain information."""
+        # Skip if PathRoutingMiddleware already handled this request
+        if getattr(request.state, "namespace", None) is not None:
+            return await call_next(request)
+
         # Skip exempt paths
         if request.url.path in self.exempt_paths:
             return await call_next(request)
@@ -130,8 +134,18 @@ class SubdomainMiddleware(BaseHTTPMiddleware):
         request.state.namespace = match.group("namespace")
         request.state.endpoint_type = EndpointType(match.group("endpoint"))
         request.state.is_local = False
+        request.state._routed_by_subdomain = True
 
-        return await call_next(request)
+        response = await call_next(request)
+
+        from mcpworks_api.config import get_settings
+
+        if get_settings().routing_mode == "both":
+            response.headers["X-MCPWorks-Deprecated"] = (
+                "subdomain-routing; migrate to /mcp/{endpoint}/{namespace}"
+            )
+
+        return response
 
     def _is_local_host(self, host: str) -> bool:
         """Check if host is a local development address."""

--- a/src/mcpworks_api/models/namespace.py
+++ b/src/mcpworks_api/models/namespace.py
@@ -32,7 +32,7 @@ class Namespace(Base, UUIDMixin, TimestampMixin):
     """Namespace model for organizing functions and services.
 
     Namespaces provide:
-    - Unique DNS subdomain ({namespace}.create.mcpworks.io, {namespace}.run.mcpworks.io)
+    - Unique MCP endpoint (/mcp/create/{namespace}, /mcp/run/{namespace})
     - Resource isolation between accounts
     - Network security controls (IP allowlisting)
     - Organizational boundary for services and functions

--- a/src/mcpworks_api/static/console.html
+++ b/src/mcpworks_api/static/console.html
@@ -1117,7 +1117,7 @@ function showGettingStarted() {
       <div id="tut-step-1" class="tut-step tut-active">
         <div class="tut-step-header"><span class="tut-num">1</span> Create a namespace</div>
         <div class="tut-step-body">
-          <div style="color:var(--text-2);font-size:13px;margin-bottom:12px">A namespace groups your services and functions under a unique subdomain.</div>
+          <div style="color:var(--text-2);font-size:13px;margin-bottom:12px">A namespace groups your services and functions under a unique endpoint.</div>
           <div id="tut-step-1-error" class="error-msg hidden" style="margin-bottom:10px"></div>
           <div style="display:flex;gap:10px;margin-bottom:10px">
             <div style="flex:1"><input id="tut-ns-name" type="text" placeholder="my-namespace" style="width:100%"></div>
@@ -1218,10 +1218,11 @@ function renderMcpConfigTabs(nsName, apiKey, envKeys, idPrefix, agentName) {
   const keyPlaceholder = hasKey ? apiKey : 'YOUR_API_KEY';
   const createKey = `mcpworks-${nsName}`;
   const runKey = `mcpworks-${nsName}-run`;
-  const createUrl = `https://${nsName}.create.mcpworks.io/mcp`;
-  const runUrl = `https://${nsName}.run.mcpworks.io/mcp`;
+  const apiBase = window.location.origin;
+  const createUrl = `${apiBase}/mcp/create/${nsName}`;
+  const runUrl = `${apiBase}/mcp/run/${nsName}`;
   const agentKey = agentName ? `mcpworks-${agentName}-agent` : null;
-  const agentUrl = agentName ? `https://${agentName}.agent.mcpworks.io/mcp` : null;
+  const agentUrl = agentName ? `${apiBase}/mcp/agent/${agentName}` : null;
   const buildCfg = (urlField) => {
     const c = { mcpServers: {} };
     c.mcpServers[createKey] = { type: 'http', [urlField]: createUrl, headers: { Authorization: `Bearer ${keyPlaceholder}` } };
@@ -2062,7 +2063,7 @@ function renderScratchpadInfo(agent) {
     return;
   }
 
-  const viewUrl = `https://${agent.name}.agent.mcpworks.io/view/${agent.scratchpad_token || '...'}/`;
+  const viewUrl = `${window.location.origin}/mcp/agent/${agent.name}/view/${agent.scratchpad_token || '...'}/`;
   const sizeKb = (agent.scratchpad_size_bytes / 1024).toFixed(1);
   const expiresAt = agent.scratchpad_expires_at ? new Date(agent.scratchpad_expires_at) : null;
 
@@ -2249,7 +2250,7 @@ async function loadAgentWebhooks(agentId) {
     el.innerHTML = hooks.map(h => `<div class="item-row">
       <div class="item-row-main">
         <div class="item-row-label"><code style="font-size:12px">/${esc(h.path)}</code> &rarr; ${esc(h.handler_function_name)}</div>
-        <div class="item-row-meta">${maskedUrl('https://' + esc(agentId) + '.agent.mcpworks.io/webhook/' + esc(h.path), 'Webhook URL')} &middot; ${h.enabled ? '<span style="color:var(--green)">enabled</span>' : '<span style="color:var(--text-3)">disabled</span>'}</div>
+        <div class="item-row-meta">${maskedUrl(window.location.origin + '/mcp/agent/' + esc(agentId) + '/webhook/' + esc(h.path), 'Webhook URL')} &middot; ${h.enabled ? '<span style="color:var(--green)">enabled</span>' : '<span style="color:var(--text-3)">disabled</span>'}</div>
       </div>
       <button class="btn btn-danger btn-sm" onclick="deleteAgentWebhook('${esc(agentId)}','${esc(h.id)}')">delete</button>
     </div>`).join('');
@@ -2747,7 +2748,7 @@ async function confirmDeleteNamespace() {
 <div id="createNsModal" class="modal-backdrop" onclick="if(event.target===this)closeCreateNsModal()">
   <div class="modal-box">
     <h3 style="color:var(--text-1)">Create Namespace</h3>
-    <div class="modal-warn">A namespace groups your services and functions under a unique subdomain.</div>
+    <div class="modal-warn">A namespace groups your services and functions under a unique endpoint.</div>
     <div id="createNsError" class="error-msg hidden" style="margin-bottom:12px"></div>
     <label>Name</label>
     <input id="createNsName" type="text" placeholder="my-namespace" autocomplete="off" spellcheck="false" onkeydown="if(event.key==='Enter')confirmCreateNamespace()">

--- a/src/mcpworks_api/static/dashboard.html
+++ b/src/mcpworks_api/static/dashboard.html
@@ -222,8 +222,8 @@ async function loadDashboard() {
                         </div>
                         <p class="text-gray-400 text-sm mb-2">${ns.description || ''}</p>
                         <div class="text-xs text-gray-500 space-y-1">
-                            <div>Create: <code class="text-gray-400">${ns.name}.create.mcpworks.io</code></div>
-                            <div>Run: <code class="text-gray-400">${ns.name}.run.mcpworks.io</code></div>
+                            <div>Create: <code class="text-gray-400">/mcp/create/${ns.name}</code></div>
+                            <div>Run: <code class="text-gray-400">/mcp/run/${ns.name}</code></div>
                         </div>
                         <div id="ns-${ns.name}-services" class="mt-3 space-y-2"></div>
                     </div>

--- a/src/mcpworks_api/static/legal/acceptable-use-policy.md
+++ b/src/mcpworks_api/static/legal/acceptable-use-policy.md
@@ -96,7 +96,7 @@ Free-tier accounts with no API activity for 180 consecutive days may have functi
 
 ## 4. Namespace Rules
 
-Your namespace (`{namespace}.create.mcpworks.io` and `{namespace}.run.mcpworks.io`) is your identity on the platform. The following naming rules apply:
+Your namespace (`/mcp/create/{namespace}` and `/mcp/run/{namespace}`) is your identity on the platform. The following naming rules apply:
 
 - **No impersonation.** Namespaces that impersonate other companies, products, or individuals are prohibited. Examples: `stripe`, `openai`, `anthropic`, `google-cloud` — unless you are that entity.
 - **No trademark infringement.** Namespaces that use trademarks you do not own or have authorization to use. We will honor valid trademark claims submitted to legal@mcpworks.io.

--- a/src/mcpworks_api/static/legal/terms-of-service.md
+++ b/src/mcpworks_api/static/legal/terms-of-service.md
@@ -34,7 +34,7 @@ These Terms are governed by the laws of British Columbia and the federal laws of
 
 ## 2. The Service
 
-MCPWorks provides namespace-based function hosting for AI assistants. You create functions through a management interface (`{namespace}.create.mcpworks.io`) and execute them through a run interface (`{namespace}.run.mcpworks.io`). Functions execute on one of several backends (Code Sandbox, nanobot.ai, or GitHub Repo).
+MCPWorks provides namespace-based function hosting for AI assistants. You create functions through a management interface (`/mcp/create/{namespace}`) and execute them through a run interface (`/mcp/run/{namespace}`). Functions execute on one of several backends (Code Sandbox, nanobot.ai, or GitHub Repo).
 
 We may offer the Service in alpha, beta, or preview stages. Features in those stages may change or be removed with 14 days notice.
 

--- a/src/mcpworks_api/static/onboarding.html
+++ b/src/mcpworks_api/static/onboarding.html
@@ -556,14 +556,14 @@
                     mcpServers: {
                         [`${namespace}-create`]: {
                             type: "http",
-                            url: `https://${namespace}.create.mcpworks.io/mcp`,
+                            url: `${window.location.origin}/mcp/create/${namespace}`,
                             headers: {
                                 Authorization: `Bearer ${state.apiKey}`
                             }
                         },
                         [`${namespace}-run`]: {
                             type: "http",
-                            url: `https://${namespace}.run.mcpworks.io/mcp`,
+                            url: `${window.location.origin}/mcp/run/${namespace}`,
                             headers: {
                                 Authorization: `Bearer ${state.apiKey}`
                             }

--- a/src/mcpworks_api/tasks/discord_gateway.py
+++ b/src/mcpworks_api/tasks/discord_gateway.py
@@ -107,14 +107,20 @@ class AgentBot(discord.Client):
 
         from mcpworks_api.config import get_settings
 
-        url = f"{get_settings().internal_api_url}/chat/{chat_token}"
+        settings = get_settings()
+        if settings.routing_mode in ("path", "both"):
+            url = f"{settings.internal_api_url}/mcp/agent/{agent_name}/chat/{chat_token}"
+            headers = {}
+        else:
+            url = f"{settings.internal_api_url}/chat/{chat_token}"
+            headers = {"Host": url_builder.agent_url(agent_name).split("://", 1)[1]}
         message = f"[Discord message from {discord_context['author']}]: {user_message}"
 
         async with httpx.AsyncClient(timeout=600.0) as client:
             resp = await client.post(
                 url,
                 json={"message": message},
-                headers={"Host": url_builder.agent_url(agent_name).split("://", 1)[1]},
+                headers=headers,
             )
 
         if resp.status_code != 200:

--- a/src/mcpworks_api/url_builder.py
+++ b/src/mcpworks_api/url_builder.py
@@ -1,7 +1,8 @@
 """Centralized URL construction for configurable domain support.
 
 All URL generation in the codebase should use these functions instead of
-hardcoding mcpworks.io. Reads BASE_DOMAIN and BASE_SCHEME from settings.
+hardcoding mcpworks.io. Supports both path-based and subdomain-based routing
+depending on ROUTING_MODE config.
 """
 
 from __future__ import annotations
@@ -15,46 +16,74 @@ def _settings():
     return get_settings()
 
 
-def _base(subdomain: str) -> str:
+def _is_path_mode() -> bool:
+    return _settings().routing_mode in ("path", "both")
+
+
+def _api_base() -> str:
+    s = _settings()
+    return f"{s.base_scheme}://api.{s.base_domain}"
+
+
+def _subdomain_base(subdomain: str) -> str:
     s = _settings()
     return f"{s.base_scheme}://{subdomain}.{s.base_domain}"
 
 
 def create_url(namespace: str) -> str:
-    return _base(f"{namespace}.create")
+    if _is_path_mode():
+        return f"{_api_base()}/mcp/create/{namespace}"
+    return _subdomain_base(f"{namespace}.create")
 
 
 def run_url(namespace: str) -> str:
-    return _base(f"{namespace}.run")
+    if _is_path_mode():
+        return f"{_api_base()}/mcp/run/{namespace}"
+    return _subdomain_base(f"{namespace}.run")
 
 
 def agent_url(agent_name: str) -> str:
-    return _base(f"{agent_name}.agent")
+    if _is_path_mode():
+        return f"{_api_base()}/mcp/agent/{agent_name}"
+    return _subdomain_base(f"{agent_name}.agent")
 
 
 def mcp_url(namespace: str, endpoint: str = "run") -> str:
-    return f"{_base(f'{namespace}.{endpoint}')}/mcp"
+    if _is_path_mode():
+        return f"{_api_base()}/mcp/{endpoint}/{namespace}"
+    return f"{_subdomain_base(f'{namespace}.{endpoint}')}/mcp"
 
 
 def api_url(path: str = "") -> str:
-    s = _settings()
-    base = f"{s.base_scheme}://api.{s.base_domain}"
+    base = _api_base()
     if path:
         return f"{base}{path}"
     return base
 
 
 def view_url(agent_name: str, token: str) -> str:
-    return f"{agent_url(agent_name)}/view/{token}/"
+    if _is_path_mode():
+        return f"{_api_base()}/mcp/agent/{agent_name}/view/{token}/"
+    return f"{_subdomain_base(f'{agent_name}.agent')}/view/{token}/"
 
 
 def chat_url(agent_name: str, token: str) -> str:
-    return f"{agent_url(agent_name)}/chat/{token}"
+    if _is_path_mode():
+        return f"{_api_base()}/mcp/agent/{agent_name}/chat/{token}"
+    return f"{_subdomain_base(f'{agent_name}.agent')}/chat/{token}"
+
+
+def webhook_url(agent_name: str, path: str) -> str:
+    if _is_path_mode():
+        return f"{_api_base()}/mcp/agent/{agent_name}/webhook/{path}"
+    return f"{_subdomain_base(f'{agent_name}.agent')}/webhook/{path}"
 
 
 @lru_cache(maxsize=1)
 def valid_suffixes() -> list[str]:
     s = _settings()
+    if s.routing_mode in ("path", "both"):
+        return ["/mcp/create/", "/mcp/run/", "/mcp/agent/"]
     return [
         f".create.{s.base_domain}",
         f".run.{s.base_domain}",

--- a/tests/unit/test_middleware_routing.py
+++ b/tests/unit/test_middleware_routing.py
@@ -1,0 +1,246 @@
+"""Unit tests for PathRoutingMiddleware."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.datastructures import URL
+
+from mcpworks_api.middleware.routing import (
+    PathRoutingMiddleware,
+    _NAMESPACE_RE,
+    _VALID_ENDPOINTS,
+)
+from mcpworks_api.middleware.subdomain import EndpointType
+
+
+class MockRequest:
+    """Mock request for testing."""
+
+    def __init__(self, path="/mcp/create/acme"):
+        self.url = URL(f"http://test{path}")
+        self.state = MagicMock()
+        self.state.namespace = None
+        self.state.endpoint_type = None
+        self.state.is_local = None
+
+
+class MockResponse:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+
+
+class TestNamespaceRegex:
+    """Tests for namespace validation regex."""
+
+    def test_simple_namespace(self):
+        assert _NAMESPACE_RE.match("acme")
+
+    def test_numeric_namespace(self):
+        assert _NAMESPACE_RE.match("ns123")
+
+    def test_hyphenated_namespace(self):
+        assert _NAMESPACE_RE.match("my-namespace")
+
+    def test_single_char(self):
+        assert _NAMESPACE_RE.match("a")
+
+    def test_max_length_63(self):
+        assert _NAMESPACE_RE.match("a" * 63)
+
+    def test_too_long_64(self):
+        assert not _NAMESPACE_RE.match("a" * 64)
+
+    def test_uppercase_rejected(self):
+        assert not _NAMESPACE_RE.match("UPPERCASE")
+
+    def test_mixed_case_rejected(self):
+        assert not _NAMESPACE_RE.match("camelCase")
+
+    def test_leading_hyphen_rejected(self):
+        assert not _NAMESPACE_RE.match("-starts-bad")
+
+    def test_trailing_hyphen_rejected(self):
+        assert not _NAMESPACE_RE.match("ends-bad-")
+
+    def test_empty_rejected(self):
+        assert not _NAMESPACE_RE.match("")
+
+    def test_spaces_rejected(self):
+        assert not _NAMESPACE_RE.match("has space")
+
+    def test_dots_rejected(self):
+        assert not _NAMESPACE_RE.match("has.dot")
+
+    def test_underscores_rejected(self):
+        assert not _NAMESPACE_RE.match("has_underscore")
+
+    def test_slash_rejected(self):
+        assert not _NAMESPACE_RE.match("has/slash")
+
+
+class TestValidEndpoints:
+    def test_valid_set(self):
+        assert _VALID_ENDPOINTS == frozenset({"create", "run", "agent"})
+
+
+class TestPathRoutingMiddlewareDispatch:
+    """Tests for PathRoutingMiddleware.dispatch."""
+
+    @pytest.fixture
+    def middleware(self):
+        return PathRoutingMiddleware(app=MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_create_endpoint(self, middleware):
+        request = MockRequest("/mcp/create/acme")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace == "acme"
+        assert request.state.endpoint_type == EndpointType.CREATE
+        assert request.state.is_local is False
+        call_next.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_endpoint(self, middleware):
+        request = MockRequest("/mcp/run/myns")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace == "myns"
+        assert request.state.endpoint_type == EndpointType.RUN
+
+    @pytest.mark.asyncio
+    async def test_agent_endpoint(self, middleware):
+        request = MockRequest("/mcp/agent/mybot")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace == "mybot"
+        assert request.state.endpoint_type == EndpointType.AGENT
+
+    @pytest.mark.asyncio
+    async def test_agent_webhook_subpath(self, middleware):
+        request = MockRequest("/mcp/agent/mybot/webhook/github/push")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace == "mybot"
+        assert request.state.endpoint_type == EndpointType.AGENT
+        call_next.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_agent_chat_subpath(self, middleware):
+        request = MockRequest("/mcp/agent/mybot/chat/tok123abc")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace == "mybot"
+        assert request.state.endpoint_type == EndpointType.AGENT
+
+    @pytest.mark.asyncio
+    async def test_agent_view_subpath(self, middleware):
+        request = MockRequest("/mcp/agent/mybot/view/tok123/")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace == "mybot"
+        assert request.state.endpoint_type == EndpointType.AGENT
+
+    @pytest.mark.asyncio
+    async def test_passes_through_non_mcp_paths(self, middleware):
+        request = MockRequest("/v1/health")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace is None
+        call_next.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_passes_through_root(self, middleware):
+        request = MockRequest("/")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace is None
+        call_next.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_passes_through_mcp_root(self, middleware):
+        """GET /mcp (discovery) should pass through — only 2 segments."""
+        request = MockRequest("/mcp")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace is None
+        call_next.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_passes_through_mcp_with_endpoint_no_ns(self, middleware):
+        """/mcp/create has only 3 segments — no namespace."""
+        request = MockRequest("/mcp/create")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace is None
+        call_next.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invalid_endpoint_raises_404(self, middleware):
+        from fastapi import HTTPException
+
+        request = MockRequest("/mcp/invalid/acme")
+        call_next = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await middleware.dispatch(request, call_next)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["code"] == "INVALID_ENDPOINT"
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_namespace_raises_400(self, middleware):
+        from fastapi import HTTPException
+
+        request = MockRequest("/mcp/create/UPPERCASE")
+        call_next = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await middleware.dispatch(request, call_next)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["code"] == "INVALID_NAMESPACE"
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_namespace_with_leading_hyphen_raises(self, middleware):
+        from fastapi import HTTPException
+
+        request = MockRequest("/mcp/create/-bad")
+        call_next = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await middleware.dispatch(request, call_next)
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_hyphenated_namespace_works(self, middleware):
+        request = MockRequest("/mcp/create/my-namespace")
+        call_next = AsyncMock(return_value=MockResponse(200))
+
+        await middleware.dispatch(request, call_next)
+
+        assert request.state.namespace == "my-namespace"
+        assert request.state.endpoint_type == EndpointType.CREATE

--- a/tests/unit/test_transport_path_matching.py
+++ b/tests/unit/test_transport_path_matching.py
@@ -1,0 +1,113 @@
+"""Unit tests for MCPTransportMiddleware path matching logic.
+
+Tests the _is_mcp_protocol_path function directly by extracting it
+without importing the full transport module (which requires the MCP SDK).
+"""
+
+import importlib
+import re
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# The transport module requires `mcp` SDK. Mock it so we can import just
+# the path-matching helper without the full dependency chain.
+_MOCK_MODULES = [
+    "mcp", "mcp.server", "mcp.server.streamable_http_manager", "mcp.types",
+]
+_saved = {}
+for mod_name in _MOCK_MODULES:
+    _saved[mod_name] = sys.modules.get(mod_name)
+    sys.modules[mod_name] = MagicMock()
+
+try:
+    # Force re-import so the mock modules are used
+    if "mcpworks_api.mcp.transport" in sys.modules:
+        del sys.modules["mcpworks_api.mcp.transport"]
+    if "mcpworks_api.mcp" in sys.modules:
+        del sys.modules["mcpworks_api.mcp"]
+
+    from mcpworks_api.mcp.transport import _is_mcp_protocol_path
+finally:
+    for mod_name in _MOCK_MODULES:
+        if _saved[mod_name] is None:
+            sys.modules.pop(mod_name, None)
+        else:
+            sys.modules[mod_name] = _saved[mod_name]
+
+
+class TestIsMcpProtocolPath:
+    """Tests for _is_mcp_protocol_path helper."""
+
+    def test_legacy_mcp_post(self):
+        assert _is_mcp_protocol_path("/mcp", "POST") is True
+
+    def test_legacy_mcp_slash_post(self):
+        assert _is_mcp_protocol_path("/mcp/", "POST") is True
+
+    def test_legacy_mcp_delete(self):
+        assert _is_mcp_protocol_path("/mcp", "DELETE") is True
+
+    def test_legacy_mcp_get_is_discovery(self):
+        """GET /mcp should NOT be intercepted — it's the discovery endpoint."""
+        assert _is_mcp_protocol_path("/mcp", "GET") is False
+
+    def test_legacy_mcp_slash_get_is_discovery(self):
+        assert _is_mcp_protocol_path("/mcp/", "GET") is False
+
+    def test_path_create_post(self):
+        assert _is_mcp_protocol_path("/mcp/create/acme", "POST") is True
+
+    def test_path_run_post(self):
+        assert _is_mcp_protocol_path("/mcp/run/myns", "POST") is True
+
+    def test_path_agent_post(self):
+        assert _is_mcp_protocol_path("/mcp/agent/mybot", "POST") is True
+
+    def test_path_create_get_sse(self):
+        """GET on path-based MCP endpoint = SSE reconnection."""
+        assert _is_mcp_protocol_path("/mcp/create/acme", "GET") is True
+
+    def test_path_run_delete(self):
+        assert _is_mcp_protocol_path("/mcp/run/acme", "DELETE") is True
+
+    def test_path_trailing_slash(self):
+        assert _is_mcp_protocol_path("/mcp/create/acme/", "POST") is True
+
+    def test_agent_webhook_not_intercepted(self):
+        assert _is_mcp_protocol_path("/mcp/agent/mybot/webhook/github", "POST") is False
+
+    def test_agent_webhook_deep_path_not_intercepted(self):
+        assert _is_mcp_protocol_path("/mcp/agent/mybot/webhook/github/push", "POST") is False
+
+    def test_agent_chat_not_intercepted(self):
+        assert _is_mcp_protocol_path("/mcp/agent/mybot/chat/tok123", "POST") is False
+
+    def test_agent_view_not_intercepted(self):
+        assert _is_mcp_protocol_path("/mcp/agent/mybot/view/tok123/", "GET") is False
+
+    def test_agent_view_subpath_not_intercepted(self):
+        assert _is_mcp_protocol_path("/mcp/agent/mybot/view/tok123/style.css", "GET") is False
+
+    def test_non_mcp_path(self):
+        assert _is_mcp_protocol_path("/v1/health", "GET") is False
+
+    def test_root_path(self):
+        assert _is_mcp_protocol_path("/", "GET") is False
+
+    def test_invalid_endpoint_not_intercepted(self):
+        assert _is_mcp_protocol_path("/mcp/invalid/ns", "POST") is False
+
+    def test_empty_method(self):
+        """Method defaults to empty string — should still work for path-based."""
+        assert _is_mcp_protocol_path("/mcp/create/acme", "") is True
+        assert _is_mcp_protocol_path("/mcp", "") is True
+
+    def test_only_endpoint_no_namespace(self):
+        """/mcp/create has only 3 segments — not a valid MCP protocol path."""
+        assert _is_mcp_protocol_path("/mcp/create", "POST") is False
+
+    def test_too_many_segments_non_agent(self):
+        """/mcp/create/ns/extra should not match (4+ segments for non-agent)."""
+        assert _is_mcp_protocol_path("/mcp/create/ns/extra", "POST") is False

--- a/tests/unit/test_url_builder.py
+++ b/tests/unit/test_url_builder.py
@@ -3,38 +3,41 @@
 from unittest.mock import MagicMock, patch
 
 
-def _mock_settings(base_domain="mcpworks.io", base_scheme="https"):
+def _mock_settings(base_domain="mcpworks.io", base_scheme="https", routing_mode="path"):
     s = MagicMock()
     s.base_domain = base_domain
     s.base_scheme = base_scheme
+    s.routing_mode = routing_mode
     return s
 
 
-class TestUrlBuilderDefault:
+class TestUrlBuilderPathMode:
+    """Tests for url_builder in path-based routing mode (default)."""
+
     def test_create_url(self):
         with patch("mcpworks_api.url_builder._settings", return_value=_mock_settings()):
             from mcpworks_api.url_builder import create_url
 
-            assert create_url("demo") == "https://demo.create.mcpworks.io"
+            assert create_url("demo") == "https://api.mcpworks.io/mcp/create/demo"
 
     def test_run_url(self):
         with patch("mcpworks_api.url_builder._settings", return_value=_mock_settings()):
             from mcpworks_api.url_builder import run_url
 
-            assert run_url("demo") == "https://demo.run.mcpworks.io"
+            assert run_url("demo") == "https://api.mcpworks.io/mcp/run/demo"
 
     def test_agent_url(self):
         with patch("mcpworks_api.url_builder._settings", return_value=_mock_settings()):
             from mcpworks_api.url_builder import agent_url
 
-            assert agent_url("bot") == "https://bot.agent.mcpworks.io"
+            assert agent_url("bot") == "https://api.mcpworks.io/mcp/agent/bot"
 
     def test_mcp_url(self):
         with patch("mcpworks_api.url_builder._settings", return_value=_mock_settings()):
             from mcpworks_api.url_builder import mcp_url
 
-            assert mcp_url("demo", "run") == "https://demo.run.mcpworks.io/mcp"
-            assert mcp_url("demo", "create") == "https://demo.create.mcpworks.io/mcp"
+            assert mcp_url("demo", "run") == "https://api.mcpworks.io/mcp/run/demo"
+            assert mcp_url("demo", "create") == "https://api.mcpworks.io/mcp/create/demo"
 
     def test_api_url(self):
         with patch("mcpworks_api.url_builder._settings", return_value=_mock_settings()):
@@ -47,16 +50,109 @@ class TestUrlBuilderDefault:
         with patch("mcpworks_api.url_builder._settings", return_value=_mock_settings()):
             from mcpworks_api.url_builder import view_url
 
-            assert view_url("bot", "tok123") == "https://bot.agent.mcpworks.io/view/tok123/"
+            assert view_url("bot", "tok123") == "https://api.mcpworks.io/mcp/agent/bot/view/tok123/"
 
     def test_chat_url(self):
         with patch("mcpworks_api.url_builder._settings", return_value=_mock_settings()):
             from mcpworks_api.url_builder import chat_url
 
+            assert chat_url("bot", "tok123") == "https://api.mcpworks.io/mcp/agent/bot/chat/tok123"
+
+    def test_webhook_url(self):
+        with patch("mcpworks_api.url_builder._settings", return_value=_mock_settings()):
+            from mcpworks_api.url_builder import webhook_url
+
+            assert (
+                webhook_url("bot", "github/push")
+                == "https://api.mcpworks.io/mcp/agent/bot/webhook/github/push"
+            )
+
+    def test_valid_suffixes_path_mode(self):
+        with patch("mcpworks_api.url_builder._settings", return_value=_mock_settings()):
+            from mcpworks_api.url_builder import valid_suffixes
+
+            valid_suffixes.cache_clear()
+            result = valid_suffixes()
+            assert "/mcp/create/" in result
+            assert "/mcp/run/" in result
+            assert "/mcp/agent/" in result
+
+
+class TestUrlBuilderSubdomainMode:
+    """Tests for url_builder in subdomain routing mode (legacy)."""
+
+    def test_create_url(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings(routing_mode="subdomain"),
+        ):
+            from mcpworks_api.url_builder import create_url
+
+            assert create_url("demo") == "https://demo.create.mcpworks.io"
+
+    def test_run_url(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings(routing_mode="subdomain"),
+        ):
+            from mcpworks_api.url_builder import run_url
+
+            assert run_url("demo") == "https://demo.run.mcpworks.io"
+
+    def test_agent_url(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings(routing_mode="subdomain"),
+        ):
+            from mcpworks_api.url_builder import agent_url
+
+            assert agent_url("bot") == "https://bot.agent.mcpworks.io"
+
+    def test_mcp_url(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings(routing_mode="subdomain"),
+        ):
+            from mcpworks_api.url_builder import mcp_url
+
+            assert mcp_url("demo", "run") == "https://demo.run.mcpworks.io/mcp"
+            assert mcp_url("demo", "create") == "https://demo.create.mcpworks.io/mcp"
+
+    def test_view_url(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings(routing_mode="subdomain"),
+        ):
+            from mcpworks_api.url_builder import view_url
+
+            assert view_url("bot", "tok123") == "https://bot.agent.mcpworks.io/view/tok123/"
+
+    def test_chat_url(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings(routing_mode="subdomain"),
+        ):
+            from mcpworks_api.url_builder import chat_url
+
             assert chat_url("bot", "tok123") == "https://bot.agent.mcpworks.io/chat/tok123"
 
-    def test_valid_suffixes(self):
-        with patch("mcpworks_api.url_builder._settings", return_value=_mock_settings()):
+    def test_webhook_url(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings(routing_mode="subdomain"),
+        ):
+            from mcpworks_api.url_builder import webhook_url
+
+            assert (
+                webhook_url("bot", "github/push")
+                == "https://bot.agent.mcpworks.io/webhook/github/push"
+            )
+
+    def test_valid_suffixes_subdomain_mode(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings(routing_mode="subdomain"),
+        ):
             from mcpworks_api.url_builder import valid_suffixes
 
             valid_suffixes.cache_clear()
@@ -66,48 +162,54 @@ class TestUrlBuilderDefault:
             assert ".agent.mcpworks.io" in result
 
 
+class TestUrlBuilderBothMode:
+    """Tests for url_builder in 'both' routing mode — path takes precedence."""
+
+    def test_create_url_uses_path(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings(routing_mode="both"),
+        ):
+            from mcpworks_api.url_builder import create_url
+
+            assert create_url("demo") == "https://api.mcpworks.io/mcp/create/demo"
+
+
 class TestUrlBuilderCustomDomain:
     def test_create_url_custom(self):
         with patch(
-            "mcpworks_api.url_builder._settings", return_value=_mock_settings("selfhost.dev")
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings("selfhost.dev", routing_mode="path"),
+        ):
+            from mcpworks_api.url_builder import create_url
+
+            assert create_url("demo") == "https://api.selfhost.dev/mcp/create/demo"
+
+    def test_create_url_custom_subdomain(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings("selfhost.dev", routing_mode="subdomain"),
         ):
             from mcpworks_api.url_builder import create_url
 
             assert create_url("demo") == "https://demo.create.selfhost.dev"
 
-    def test_run_url_custom(self):
-        with patch(
-            "mcpworks_api.url_builder._settings", return_value=_mock_settings("selfhost.dev")
-        ):
-            from mcpworks_api.url_builder import run_url
-
-            assert run_url("demo") == "https://demo.run.selfhost.dev"
-
-    def test_agent_url_custom(self):
-        with patch(
-            "mcpworks_api.url_builder._settings", return_value=_mock_settings("selfhost.dev")
-        ):
-            from mcpworks_api.url_builder import agent_url
-
-            assert agent_url("bot") == "https://bot.agent.selfhost.dev"
-
-    def test_valid_suffixes_custom(self):
-        with patch(
-            "mcpworks_api.url_builder._settings", return_value=_mock_settings("selfhost.dev")
-        ):
-            from mcpworks_api.url_builder import valid_suffixes
-
-            valid_suffixes.cache_clear()
-            result = valid_suffixes()
-            assert ".create.selfhost.dev" in result
-            assert ".run.selfhost.dev" in result
-            assert ".agent.selfhost.dev" in result
-
 
 class TestUrlBuilderHttpScheme:
-    def test_urls_use_http(self):
+    def test_urls_use_http_path_mode(self):
         with patch(
-            "mcpworks_api.url_builder._settings", return_value=_mock_settings("localhost", "http")
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings("localhost", "http", routing_mode="path"),
+        ):
+            from mcpworks_api.url_builder import api_url, create_url
+
+            assert create_url("demo") == "http://api.localhost/mcp/create/demo"
+            assert api_url() == "http://api.localhost"
+
+    def test_urls_use_http_subdomain_mode(self):
+        with patch(
+            "mcpworks_api.url_builder._settings",
+            return_value=_mock_settings("localhost", "http", routing_mode="subdomain"),
         ):
             from mcpworks_api.url_builder import api_url, create_url
 


### PR DESCRIPTION
## Summary

- Replace `{ns}.{endpoint}.mcpworks.io` subdomain routing with `/mcp/{endpoint}/{namespace}` path-based routing
- Eliminates wildcard DNS, wildcard TLS, and DNS-01 ACME — self-hosted installs work with just an IP address
- New `ROUTING_MODE` config: `path` (default), `subdomain` (legacy), `both` (transition)
- Full spec kit at `specs/015-path-based-routing/`
- 117 tests passing (74 new + 43 existing)
- Documentation sweep across 44 files

## Test plan

- [ ] Verify `pytest tests/unit/test_middleware_routing.py tests/unit/test_url_builder.py tests/unit/test_transport_path_matching.py` passes
- [ ] Verify existing `test_middleware_subdomain.py` still passes (backward compat)
- [ ] Test MCP connection via `/mcp/create/{ns}` on local dev server
- [ ] Test MCP connection via `/mcp/run/{ns}` on local dev server
- [ ] Test agent webhook via `/mcp/agent/{ns}/webhook/{path}`
- [ ] Verify `GET /mcp` returns discovery JSON
- [ ] Verify `ROUTING_MODE=subdomain` preserves legacy behavior
- [ ] Deploy to staging and verify Caddy config works with single-origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)