### PR TITLE
OAuth 2.0 for MCP server proxy (RFC 8628 device flow)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ specs/                  # Speckit artifacts per feature
 - Python 3.11+ + FastAPI 0.109+, SQLAlchemy 2.0+ (async), httpx (async HTTP client), Pydantic v2, structlog (023-telemetry-webhook)
 - PostgreSQL 15+ (webhook config on namespaces table), Redis 7+ (optional batching buffer) (023-telemetry-webhook)
 - PostgreSQL 15+ (new trust_score columns on `agents` table) (024-trust-scoring-and-compliance)
+- Python 3.11+ (existing codebase) + FastAPI 0.109+ (existing), Authlib 1.3+ (existing), httpx (existing), SQLAlchemy 2.0+ (existing) (026-oauth-mcp-proxy)
+- PostgreSQL 15+ (5 new columns on `namespace_mcp_servers`), Redis 7+ (ephemeral device flow state) (026-oauth-mcp-proxy)
 
 ## Recent Changes
 - 001-api-gateway-mvp: Added Python 3.11+ + FastAPI 0.109+, SQLAlchemy 2.0+ (async), Pydantic v2, httpx, PyJWT, argon2-cffi, stripe

--- a/alembic/versions/20260413_000001_add_mcp_oauth.py
+++ b/alembic/versions/20260413_000001_add_mcp_oauth.py
@@ -1,0 +1,50 @@
+"""Add OAuth columns to namespace_mcp_servers.
+
+Revision ID: 20260413_000001
+Revises: 20260412_000001
+Create Date: 2026-04-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260413_000001"
+down_revision = "20260412_000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "namespace_mcp_servers",
+        sa.Column("auth_type", sa.String(20), nullable=False, server_default="bearer"),
+    )
+    op.add_column(
+        "namespace_mcp_servers",
+        sa.Column("oauth_config_encrypted", sa.LargeBinary(), nullable=True),
+    )
+    op.add_column(
+        "namespace_mcp_servers",
+        sa.Column("oauth_config_dek", sa.LargeBinary(), nullable=True),
+    )
+    op.add_column(
+        "namespace_mcp_servers",
+        sa.Column("oauth_tokens_encrypted", sa.LargeBinary(), nullable=True),
+    )
+    op.add_column(
+        "namespace_mcp_servers",
+        sa.Column("oauth_tokens_dek", sa.LargeBinary(), nullable=True),
+    )
+    op.add_column(
+        "namespace_mcp_servers",
+        sa.Column("oauth_tokens_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("namespace_mcp_servers", "oauth_tokens_expires_at")
+    op.drop_column("namespace_mcp_servers", "oauth_tokens_dek")
+    op.drop_column("namespace_mcp_servers", "oauth_tokens_encrypted")
+    op.drop_column("namespace_mcp_servers", "oauth_config_dek")
+    op.drop_column("namespace_mcp_servers", "oauth_config_encrypted")
+    op.drop_column("namespace_mcp_servers", "auth_type")

--- a/specs/026-oauth-mcp-proxy/data-model.md
+++ b/specs/026-oauth-mcp-proxy/data-model.md
@@ -1,0 +1,84 @@
+# Data Model: OAuth for MCP Server Proxy
+
+**Feature**: 026-oauth-mcp-proxy | **Date**: 2026-04-12
+
+## Modified Entity: NamespaceMcpServer
+
+### New Columns
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| auth_type | varchar(20) | NO | "bearer" | "bearer", "oauth2", "none" |
+| oauth_config_encrypted | bytea | YES | NULL | Encrypted: client_id, client_secret, scopes, device_authorization_endpoint, token_endpoint, auth_endpoint (fallback) |
+| oauth_config_dek | bytea | YES | NULL | DEK for oauth_config |
+| oauth_tokens_encrypted | bytea | YES | NULL | Encrypted: access_token, refresh_token, token_type, scope |
+| oauth_tokens_dek | bytea | YES | NULL | DEK for oauth_tokens |
+| oauth_tokens_expires_at | timestamptz | YES | NULL | Access token expiry (plaintext for proactive refresh check without decryption) |
+
+### Encryption Details
+
+`oauth_config_encrypted` stores (via `encrypt_value()`):
+```json
+{
+  "client_id": "...",
+  "client_secret": "...",
+  "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+  "device_authorization_endpoint": "https://oauth2.googleapis.com/device/code",
+  "token_endpoint": "https://oauth2.googleapis.com/token",
+  "auth_endpoint": "https://accounts.google.com/o/oauth2/auth",
+  "flow": "device"
+}
+```
+
+`oauth_tokens_encrypted` stores (via `encrypt_value()`):
+```json
+{
+  "access_token": "ya29.a0...",
+  "refresh_token": "1//0e...",
+  "token_type": "Bearer",
+  "scope": "https://www.googleapis.com/auth/gmail.readonly"
+}
+```
+
+`oauth_tokens_expires_at` stored in plaintext so `proxy_mcp_call()` can check expiry without decrypting (performance: avoid decrypt on every call when token is fresh).
+
+### Validation Rules
+
+- `auth_type` must be one of: "bearer", "oauth2", "none"
+- If `auth_type = "oauth2"`, `oauth_config_encrypted` must not be NULL
+- If `auth_type = "oauth2"` and `flow = "device"`, `device_authorization_endpoint` must be in config
+- `oauth_tokens_expires_at` updated on every token refresh
+- Setting `auth_type` to something other than "oauth2" clears all oauth_* columns
+
+### State Transitions
+
+```
+No Token → AUTH_REQUIRED (device code issued)
+AUTH_REQUIRED → Polling (background task active)
+Polling → Tokens Stored (user approved)
+Polling → Expired (user never approved, code expired)
+Expired → AUTH_REQUIRED (next tool call generates fresh code)
+
+Tokens Stored → Token Refresh (access_token expired, refresh_token valid)
+Token Refresh → Tokens Stored (refresh succeeded, new tokens)
+Token Refresh → AUTH_REQUIRED (refresh_token revoked/expired)
+```
+
+## Redis State (Ephemeral)
+
+| Key Pattern | Value | TTL | Purpose |
+|-------------|-------|-----|---------|
+| `mcp_oauth_device:{ns_id}:{server}` | JSON: `{device_code, user_code, verification_uri, interval, expires_at}` | Provider-specified (typically 600s) | Active device code — prevents duplicate generation |
+| `mcp_oauth_polling:{ns_id}:{server}` | `"1"` | Same as device code | Flag: background poller is active for this server |
+| `mcp_oauth_refresh:{ns_id}:{server}` | `"1"` | 30s | Lock: prevent concurrent refresh requests |
+
+## Relationships
+
+```
+Namespace (1) → (N) NamespaceMcpServer
+  └── auth_type: "bearer" → uses headers_encrypted (existing)
+  └── auth_type: "oauth2" → uses oauth_config_encrypted + oauth_tokens_encrypted (new)
+  └── auth_type: "none" → no auth headers attached
+```
+
+No new tables. No new relationships. All changes are additive columns on existing `namespace_mcp_servers`.

--- a/specs/026-oauth-mcp-proxy/plan.md
+++ b/specs/026-oauth-mcp-proxy/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: OAuth for MCP Server Proxy
+
+**Branch**: `026-oauth-mcp-proxy` | **Date**: 2026-04-12 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/026-oauth-mcp-proxy/spec.md`
+
+## Summary
+
+Add OAuth 2.0 support to the MCP server proxy so external MCP servers (Google Workspace, Slack, GitHub) can be authenticated with user consent. Primary method is RFC 8628 Device Authorization Flow (enter-a-code UX), with Authorization Code Flow as fallback. Tokens are per-namespace, encrypted at rest, refreshed proactively, and surfaced to users via structured HITL responses that the AI can present conversationally.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (existing codebase)
+**Primary Dependencies**: FastAPI 0.109+ (existing), Authlib 1.3+ (existing), httpx (existing), SQLAlchemy 2.0+ (existing)
+**Storage**: PostgreSQL 15+ (5 new columns on `namespace_mcp_servers`), Redis 7+ (ephemeral device flow state)
+**Testing**: pytest with async fixtures; mock httpx for OAuth endpoint responses
+**Target Platform**: Linux server (existing mcpworks-api container)
+**Project Type**: Single backend API
+**Performance Goals**: Token refresh <500ms; zero added latency when tokens are fresh (plaintext `expires_at` check only)
+**Constraints**: Never store tokens unencrypted; never log tokens; device flow polling must not block request handling
+**Scale/Scope**: Up to 50 OAuth-protected MCP servers per namespace; 1 active device flow per server
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-First Development | PASS | Spec complete with all questions resolved before planning |
+| II. Token Efficiency & Streaming | PASS | AUTH_REQUIRED response is <200 tokens; no impact on normal tool call responses |
+| III. Transaction Safety & Security | PASS | Tokens encrypted at rest (AES-256-GCM envelope); CSRF protection on callbacks; refresh lock prevents concurrent refreshes; informed consent disclosure |
+| IV. Provider Abstraction & Observability | PASS | Provider-agnostic (any RFC 8628 / RFC 6749 provider); Prometheus metrics for auth events; structlog for token operations |
+| V. API Contracts & Test Coverage | PASS | No breaking changes to existing MCP tools; `auth_type` defaults to "bearer" (backward compatible); unit tests for all flows |
+
+| Quality Standard | Status | Notes |
+|-----------------|--------|-------|
+| Code Quality | PASS | ruff enforced; type hints on all new functions |
+| Documentation | PASS | quickstart.md with examples for device flow and auth code fallback |
+| Performance | PASS | Proactive refresh avoids latency on tool calls; plaintext expires_at check |
+| Security | PASS | AES-256-GCM envelope encryption; no tokens in logs; CSRF on callbacks |
+
+**No violations.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/026-oauth-mcp-proxy/
+├── spec.md              # Feature specification (complete)
+├── plan.md              # This file
+├── research.md          # Research decisions (complete)
+├── data-model.md        # Data model changes (complete)
+├── quickstart.md        # Usage examples (complete)
+└── tasks.md             # Implementation tasks (next: /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/mcpworks_api/
+├── services/
+│   └── mcp_oauth.py           # NEW: OAuth token management (device flow, refresh, storage)
+├── tasks/
+│   └── device_flow_poller.py   # NEW: Background polling for device code approval
+├── api/v1/
+│   └── mcp_oauth.py            # NEW: Callback endpoint for auth code fallback
+├── models/
+│   └── namespace_mcp_server.py # MODIFY: Add 5 OAuth columns
+├── core/
+│   └── mcp_proxy.py            # MODIFY: Token refresh before proxy call
+│   └── mcp_pool.py             # MODIFY: Evict on token refresh
+├── main.py                     # MODIFY: Register callback router
+├── middleware/
+│   └── observability.py        # MODIFY: Add oauth_* Prometheus metrics
+└── config.py                   # MODIFY: Optional MCP OAuth settings
+
+alembic/versions/
+└── 20260413_000001_add_mcp_oauth.py  # NEW: Migration for 5 columns
+
+tests/unit/
+├── test_mcp_oauth_service.py   # NEW: Token lifecycle tests
+├── test_device_flow_poller.py  # NEW: Poller behavior tests
+└── test_mcp_proxy_oauth.py     # NEW: Proxy integration with OAuth
+```
+
+**Structure Decision**: All new code fits within existing directories. Three new files (service, poller, callback endpoint), plus modifications to existing proxy/pool/model/config. No new packages or structural changes.
+
+## Implementation Phases
+
+### Phase 1: Data Model + OAuth Service (Foundation)
+
+**Deliverables**: Migration, model changes, core OAuth service
+
+1. Add 5 columns to `namespace_mcp_servers` model + Alembic migration
+2. Create `services/mcp_oauth.py`:
+   - `initiate_device_flow(server, db)` → requests device code, stores in Redis, returns AUTH_REQUIRED response
+   - `initiate_auth_code_flow(server, db)` → generates auth URL with state, returns AUTH_REQUIRED response
+   - `exchange_device_code(server, device_code, db)` → exchanges for tokens, encrypts, stores in DB
+   - `exchange_auth_code(server, code, db)` → exchanges for tokens, encrypts, stores in DB
+   - `refresh_token_if_needed(server, db)` → checks expires_at, refreshes proactively, returns fresh headers
+   - `get_oauth_headers(server, db)` → decrypt tokens, return as Authorization header dict
+3. Unit tests for all service methods (mock httpx responses)
+
+### Phase 2: Proxy Integration + Device Flow Poller
+
+**Deliverables**: Token refresh in proxy, background poller, auth code callback
+
+1. Modify `core/mcp_proxy.py`:
+   - Before `get_or_connect()`: if `server.auth_type == "oauth2"`, call `refresh_token_if_needed()`
+   - If no tokens exist, call `initiate_device_flow()` or `initiate_auth_code_flow()`, return AUTH_REQUIRED as ProxyResult
+   - On 401 from external server: attempt refresh, retry once
+   - On refresh failure: return AUTH_REQUIRED
+2. Create `tasks/device_flow_poller.py`:
+   - `poll_device_code(namespace_id, server_name)` — async task, polls token endpoint at provider interval
+   - Handles: `authorization_pending` (continue), `slow_down` (increase interval), `expired_token` (stop), success (store tokens)
+   - Redis-keyed to prevent duplicate pollers
+3. Create `api/v1/mcp_oauth.py`:
+   - `GET /v1/oauth/mcp-callback` — auth code callback (fallback flow only)
+   - Validates state from Redis, exchanges code for tokens, stores encrypted
+   - Returns HTML success page with informed consent disclosure
+4. Register callback router in `main.py`
+5. Unit tests for proxy OAuth path + poller + callback
+
+### Phase 3: MCP Tool Integration + Observability
+
+**Deliverables**: add_mcp_server changes, describe output, Prometheus metrics
+
+1. Update `add_mcp_server` tool handler to accept `auth_type` and `oauth_config`
+2. Update `update_mcp_server` to handle scope changes (invalidate tokens)
+3. Update `describe_mcp_server` to include `oauth_status`, `oauth_scopes`, `oauth_expires_at`
+4. Update `remove_mcp_server` to clean up OAuth tokens and Redis state
+5. Add Prometheus metrics:
+   - `mcpworks_oauth_token_refreshes_total` [namespace, server, status]
+   - `mcpworks_oauth_device_flows_total` [namespace, server, status]
+   - `mcpworks_oauth_auth_required_total` [namespace, server, flow]
+6. Update self-hosting docs with OAuth configuration section
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/026-oauth-mcp-proxy/quickstart.md
+++ b/specs/026-oauth-mcp-proxy/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart: OAuth MCP Server Proxy
+
+## Register an OAuth-protected MCP Server
+
+```
+add_mcp_server(
+  name="google_workspace",
+  url="https://google-workspace-mcp.example.com/mcp",
+  transport="streamable_http",
+  auth_type="oauth2",
+  oauth_config={
+    "client_id": "123456789.apps.googleusercontent.com",
+    "client_secret": "GOCSPX-...",
+    "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+    "device_authorization_endpoint": "https://oauth2.googleapis.com/device/code",
+    "token_endpoint": "https://oauth2.googleapis.com/token",
+    "flow": "device"
+  }
+)
+```
+
+## First Tool Call — HITL Authorization
+
+When the AI calls a tool on an unauthorized OAuth server:
+
+```python
+from functions import google_workspace__list_emails
+result = google_workspace__list_emails({"max_results": 5})
+```
+
+The proxy returns:
+
+```json
+{
+  "auth_required": true,
+  "provider": "google_workspace",
+  "verification_uri": "https://www.google.com/device",
+  "user_code": "WDJB-MJHT",
+  "message": "Authorization required for google_workspace. Go to https://www.google.com/device and enter code WDJB-MJHT to grant access. The system will detect authorization automatically — just retry after approving.",
+  "expires_in": 600,
+  "flow": "device"
+}
+```
+
+The AI surfaces this to the user:
+
+> To use Google Workspace, go to **google.com/device** and enter code **WDJB-MJHT**. Let me know when you've approved it.
+
+After the user approves, the background poller detects it and stores the tokens. The AI retries and the call succeeds.
+
+## Subsequent Calls — Transparent
+
+All future tool calls to `google_workspace` work without any user interaction. Token refresh happens silently in the background.
+
+## Authorization Code Fallback
+
+For providers that don't support device flow (e.g., Slack):
+
+```
+add_mcp_server(
+  name="slack",
+  url="https://slack-mcp.example.com/mcp",
+  transport="streamable_http",
+  auth_type="oauth2",
+  oauth_config={
+    "client_id": "12345.67890",
+    "client_secret": "abc...",
+    "scopes": ["chat:write", "channels:read"],
+    "auth_endpoint": "https://slack.com/oauth/v2/authorize",
+    "token_endpoint": "https://slack.com/api/oauth.v2.access",
+    "flow": "authorization_code"
+  }
+)
+```
+
+The proxy returns an `auth_url` instead of a `user_code`:
+
+```json
+{
+  "auth_required": true,
+  "provider": "slack",
+  "auth_url": "https://slack.com/oauth/v2/authorize?client_id=...&scope=...&state=...",
+  "message": "Authorization required for slack. Open this URL to grant access, then retry.",
+  "expires_in": 600,
+  "flow": "authorization_code"
+}
+```
+
+## Check OAuth Status
+
+```
+describe_mcp_server(name="google_workspace")
+```
+
+Response includes:
+
+```json
+{
+  "name": "google_workspace",
+  "auth_type": "oauth2",
+  "oauth_status": "authorized",
+  "oauth_scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+  "oauth_expires_at": "2026-04-12T05:30:00Z"
+}
+```
+
+Possible `oauth_status` values: `"not_configured"`, `"pending_authorization"`, `"authorized"`, `"expired"` (refresh token revoked).

--- a/specs/026-oauth-mcp-proxy/research.md
+++ b/specs/026-oauth-mcp-proxy/research.md
@@ -1,0 +1,75 @@
+# Research: OAuth for MCP Server Proxy
+
+**Feature**: 026-oauth-mcp-proxy | **Date**: 2026-04-12
+
+## R1: OAuth 2.0 Device Authorization Flow (RFC 8628)
+
+**Decision**: Use device flow as the primary authorization method for MCP server OAuth.
+
+**Rationale**: Device flow doesn't require a callback URL (works behind NATs, self-hosted), produces a clean "enter this code" UX for terminal MCP clients, and the background polling model fits the agentic pattern where the AI retries after the user approves.
+
+**Alternatives considered**:
+- Authorization code flow (standard browser redirect) — requires public callback URL, awkward in CLI contexts. Kept as fallback.
+- Client credentials flow — no user consent, only works for service-to-service. Not applicable when accessing user data (e.g., Google Workspace emails).
+
+## R2: Authlib Device Flow Support
+
+**Decision**: Use Authlib 1.3+ (already a dependency) for the OAuth client. Authlib supports device authorization via standard HTTP calls to device_authorization_endpoint and token_endpoint.
+
+**Rationale**: Authlib is already configured for social login (Google, GitHub). The device flow is standard RFC 8628 — two HTTP calls: POST to device_authorization_endpoint, then POST to token_endpoint with `grant_type=urn:ietf:params:oauth:grant-type:device_code`.
+
+**Alternatives considered**:
+- Raw httpx calls — works but reinvents token parsing, error handling, and JWT validation that Authlib provides.
+- python-social-auth — additional dependency, no advantage over Authlib already in use.
+
+## R3: Token Storage Pattern
+
+**Decision**: Use the existing envelope encryption pattern (AES-256-GCM) from `core/encryption.py`. Add 5 new columns to `namespace_mcp_servers`.
+
+**Rationale**: Same pattern used for `headers_encrypted`. No new crypto infrastructure needed. `encrypt_value()` / `decrypt_value()` handle JSON serialization, per-value random DEKs, and KEK wrapping.
+
+**Alternatives considered**:
+- Separate `mcp_oauth_tokens` table — unnecessary normalization, joins add latency to every proxy call.
+- Store tokens in `settings` JSONB — not encrypted at rest, violates security standards.
+
+## R4: Token Refresh Strategy
+
+**Decision**: Proactive refresh via background task, with reactive 401-handling as fallback.
+
+**Rationale**: Proactive refresh (check `expires_at`, refresh 5 min before expiry) avoids adding latency to tool calls. The background poller pattern already exists for agent schedules (`tasks/scheduler.py`). Reactive fallback catches edge cases where tokens are revoked between refresh and use.
+
+**Alternatives considered**:
+- Lazy refresh only (on 401) — simpler but adds 1-2s latency to the first call after expiry. Unacceptable for code-mode where multiple MCP calls may chain.
+- Separate refresh service/worker — overkill; a single async loop in the existing lifespan is sufficient.
+
+## R5: Device Code Polling Architecture
+
+**Decision**: On-demand background task per device flow initiation, not a persistent polling loop.
+
+**Rationale**: Unlike the scheduler (which runs continuously), device flow polling is ephemeral — it starts when a user initiates auth and stops when they approve (or the code expires). Spawning `asyncio.create_task()` per initiation, keyed in Redis to prevent duplicates, is cleaner than a persistent loop that checks "is anyone currently authorizing?"
+
+**Implementation**:
+- First tool call with no token → request device code → store in Redis → spawn poller task → return AUTH_REQUIRED
+- Poller polls token endpoint every `interval` seconds (from provider response, typically 5s)
+- On success: encrypt + store tokens in DB, delete Redis state, cancel task
+- On expiry: delete Redis state, task exits naturally
+- On duplicate request (poller already running): return existing user_code from Redis
+
+## R6: Per-Namespace Token Scope
+
+**Decision**: OAuth tokens are per-namespace, not per-user. See spec Q4 resolution.
+
+**Rationale**: The namespace is the identity boundary. Agent cron triggers need tokens without a user context. Per-user would require solving "whose token does the agent use at 3am?"
+
+## R7: Provider Support Matrix
+
+**Decision**: Support any OAuth 2.0 provider that implements device flow or authorization code flow. No provider-specific logic beyond endpoint URLs and scopes.
+
+**Rationale**: The proxy should be provider-agnostic. Users supply `device_authorization_endpoint`, `token_endpoint`, `client_id`, `client_secret`, and `scopes`. The proxy doesn't need to know it's talking to Google vs Slack vs GitHub — it just speaks RFC 8628 / RFC 6749.
+
+**Known provider support for device flow**:
+- Google: YES (device flow supported)
+- GitHub: YES (device flow supported)
+- Microsoft/Azure AD: YES (device flow supported)
+- Slack: NO (authorization code only — use fallback)
+- Linear: NO (authorization code only — use fallback)

--- a/specs/026-oauth-mcp-proxy/tasks.md
+++ b/specs/026-oauth-mcp-proxy/tasks.md
@@ -1,0 +1,224 @@
+# Tasks: OAuth for MCP Server Proxy
+
+**Input**: Design documents from `/specs/026-oauth-mcp-proxy/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Included — security-critical feature requires unit test coverage for token lifecycle, device flow polling, and proxy integration.
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Database migration and model changes
+
+- [ ] T001 Add `auth_type`, `oauth_config_encrypted`, `oauth_config_dek`, `oauth_tokens_encrypted`, `oauth_tokens_dek`, `oauth_tokens_expires_at` columns to NamespaceMcpServer model in src/mcpworks_api/models/namespace_mcp_server.py
+- [ ] T002 Add `auth_type` validator (must be "bearer", "oauth2", or "none") and defaults (auth_type="bearer") in src/mcpworks_api/models/namespace_mcp_server.py
+- [ ] T003 Create Alembic migration for OAuth columns in alembic/versions/20260413_000001_add_mcp_oauth.py
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core OAuth service that all user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T004 Create `services/mcp_oauth.py` with `McpOAuthService` class — constructor takes `db: AsyncSession`, holds reference to encryption helpers in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T005 Implement `_encrypt_oauth_config(config: dict) -> tuple[bytes, bytes]` and `_decrypt_oauth_config(server) -> dict` using existing `encrypt_value`/`decrypt_value` from core/encryption.py in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T006 Implement `_encrypt_oauth_tokens(tokens: dict) -> tuple[bytes, bytes]` and `_decrypt_oauth_tokens(server) -> dict` using same encryption pattern in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T007 Implement `get_oauth_status(server) -> str` — returns "not_configured", "pending_authorization", "authorized", or "expired" based on auth_type, token presence, and expires_at in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T008 [P] Create unit tests for encryption round-trip and status logic in tests/unit/test_mcp_oauth_service.py
+
+**Checkpoint**: OAuth service foundation exists — encryption, decryption, status checking
+
+---
+
+## Phase 3: User Story 1 — First-Time OAuth Setup via Device Flow (Priority: P0)
+
+**Goal**: User registers an OAuth MCP server and completes authorization via RFC 8628 device flow
+
+**Independent Test**: Call `add_mcp_server` with `auth_type="oauth2"`, trigger a tool call, verify AUTH_REQUIRED response with user_code and verification_uri, mock provider approval, verify tokens stored
+
+### Tests for User Story 1
+
+- [ ] T009 [P] [US1] Unit test: `initiate_device_flow()` requests device code from provider, stores in Redis, returns AUTH_REQUIRED response in tests/unit/test_mcp_oauth_service.py
+- [ ] T010 [P] [US1] Unit test: `exchange_device_code()` exchanges code for tokens, encrypts, stores in DB in tests/unit/test_mcp_oauth_service.py
+- [ ] T011 [P] [US1] Unit test: device flow poller handles `authorization_pending`, `slow_down`, `expired_token`, and success responses in tests/unit/test_device_flow_poller.py
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] Implement `initiate_device_flow(server, db) -> dict` — POST to device_authorization_endpoint with client_id + scope, store device_code/user_code/interval in Redis (`mcp_oauth_device:{ns_id}:{server_name}`, TTL from provider), return AUTH_REQUIRED response dict in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T013 [US1] Implement `exchange_device_code(server, device_code, db)` — POST to token_endpoint with `grant_type=urn:ietf:params:oauth:grant-type:device_code`, encrypt tokens, store in DB, update `oauth_tokens_expires_at`, delete Redis device state in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T014 [US1] Implement `get_active_device_code(server) -> dict | None` — check Redis for active device code, return existing user_code/verification_uri if poller is already running (prevent duplicate generation) in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T015 [US1] Create `tasks/device_flow_poller.py` with `poll_device_code(namespace_id, server_name)` — async task that polls token_endpoint every `interval` seconds, handles RFC 8628 error responses, calls `exchange_device_code` on success, exits on expiry in src/mcpworks_api/tasks/device_flow_poller.py
+- [ ] T016 [US1] Integrate device flow into proxy: in `proxy_mcp_call()`, if `server.auth_type == "oauth2"` and no tokens, check for active device code (return existing AUTH_REQUIRED) or call `initiate_device_flow()` + spawn poller via `asyncio.create_task()`, return AUTH_REQUIRED as ProxyResult in src/mcpworks_api/core/mcp_proxy.py
+
+**Checkpoint**: Device flow end-to-end works — AUTH_REQUIRED returned, poller runs, tokens stored on approval
+
+---
+
+## Phase 4: User Story 2 — Silent Token Refresh (Priority: P0)
+
+**Goal**: Expired access tokens are refreshed transparently using the stored refresh token
+
+**Independent Test**: Store tokens with expired `oauth_tokens_expires_at`, trigger tool call, verify refresh happens before proxy call, verify new tokens stored
+
+### Tests for User Story 2
+
+- [ ] T017 [P] [US2] Unit test: `refresh_token_if_needed()` refreshes when expires_at < now + 5min in tests/unit/test_mcp_oauth_service.py
+- [ ] T018 [P] [US2] Unit test: `refresh_token_if_needed()` returns existing tokens when still fresh in tests/unit/test_mcp_oauth_service.py
+- [ ] T019 [P] [US2] Unit test: refresh failure with `invalid_grant` triggers re-auth (returns AUTH_REQUIRED) in tests/unit/test_mcp_oauth_service.py
+- [ ] T020 [P] [US2] Unit test: concurrent refresh requests use Redis lock, only one refresh executes in tests/unit/test_mcp_oauth_service.py
+
+### Implementation for User Story 2
+
+- [ ] T021 [US2] Implement `refresh_token_if_needed(server, db) -> dict` — check `oauth_tokens_expires_at`, if within 5 min of expiry: acquire Redis lock (`mcp_oauth_refresh:{ns_id}:{server}`, 30s TTL), POST to token_endpoint with `grant_type=refresh_token`, encrypt + store new tokens, update expires_at, release lock. Return decrypted headers dict in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T022 [US2] Implement `get_oauth_headers(server, db) -> dict` — if tokens fresh, decrypt and return `{"Authorization": "Bearer {access_token}"}`. If stale, call `refresh_token_if_needed`. If refresh fails with invalid_grant, return None (caller handles as AUTH_REQUIRED) in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T023 [US2] Integrate refresh into proxy: in `proxy_mcp_call()`, replace static header decryption with `get_oauth_headers()` for oauth2 servers. On None return, initiate device/auth code flow. On 401 from external server, attempt one refresh + retry before returning AUTH_REQUIRED in src/mcpworks_api/core/mcp_proxy.py
+- [ ] T024 [US2] Evict MCP pool connection after token refresh — call `mcp_pool.evict()` when tokens change so new connection uses fresh headers in src/mcpworks_api/core/mcp_proxy.py
+
+**Checkpoint**: Token lifecycle is fully automated — proactive refresh, reactive 401 handling, concurrent-safe
+
+---
+
+## Phase 5: User Story 3 — HITL Auth Surfacing Through LLM (Priority: P0)
+
+**Goal**: AUTH_REQUIRED responses are structured for AI agents to present naturally in conversation
+
+**Independent Test**: Trigger tool call on unauthorized server, verify response structure, verify AI can extract user_code and verification_uri, verify retry after approval succeeds
+
+### Implementation for User Story 3
+
+- [ ] T025 [US3] Ensure AUTH_REQUIRED ProxyResult in `proxy_mcp_call()` uses the structured format from spec (auth_required, provider, verification_uri, user_code, message, expires_in, flow) — not a generic error in src/mcpworks_api/core/mcp_proxy.py
+- [ ] T026 [US3] In code-mode execution: verify sandbox code calling an unauthorized MCP tool gets the AUTH_REQUIRED dict as a function return value (not an exception/crash) — trace through `_execute_namespace_function` → `mcp_pool.call_tool()` → ProxyResult flow in src/mcpworks_api/mcp/code_mode.py and src/mcpworks_api/tasks/orchestrator.py
+- [ ] T027 [US3] On retry while poller is active: return same user_code and verification_uri from Redis (via `get_active_device_code()`) with message "Authorization still pending — polling for approval" in src/mcpworks_api/core/mcp_proxy.py
+
+**Checkpoint**: AI agents can present device flow authorization naturally in any MCP client
+
+---
+
+## Phase 6: User Story 4 — OAuth Config via MCP Tools (Priority: P1)
+
+**Goal**: Namespace owners configure OAuth through existing add/update/describe/remove MCP tools
+
+**Independent Test**: Call `add_mcp_server` with `auth_type="oauth2"` and `oauth_config`, verify encrypted storage, call `describe_mcp_server` to see oauth_status
+
+### Implementation for User Story 4
+
+- [ ] T028 [US4] Update `add_mcp_server` tool handler to accept `auth_type` and `oauth_config` parameters — validate config structure, encrypt and store in src/mcpworks_api/services/mcp_server.py and src/mcpworks_api/mcp/tool_registry.py
+- [ ] T029 [US4] Update `update_mcp_server` tool handler — if scopes change, clear stored tokens (require re-auth) in src/mcpworks_api/services/mcp_server.py
+- [ ] T030 [US4] Update `describe_mcp_server` response to include `oauth_status`, `oauth_scopes`, `oauth_expires_at` (never expose tokens or client_secret) in src/mcpworks_api/services/mcp_server.py
+- [ ] T031 [US4] Update `remove_mcp_server` to clean up OAuth tokens, Redis device state, and cancel any active poller in src/mcpworks_api/services/mcp_server.py
+- [ ] T032 [P] [US4] Unit test: add_mcp_server with oauth2 config stores encrypted config, describe returns status in tests/unit/test_mcp_server_service.py
+
+**Checkpoint**: Full CRUD lifecycle for OAuth MCP servers via existing MCP tools
+
+---
+
+## Phase 7: User Story 5 — Multiple OAuth Providers per Namespace (Priority: P2)
+
+**Goal**: Multiple OAuth MCP servers coexist independently per namespace
+
+**Independent Test**: Register google_workspace and slack, authorize google only, verify slack returns AUTH_REQUIRED while google works
+
+### Implementation for User Story 5
+
+- [ ] T033 [US5] Verify all Redis keys are scoped by `{namespace_id}:{server_name}` — no cross-server state leakage in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T034 [US5] Verify proxy correctly routes to per-server OAuth tokens — test with two oauth2 servers where one is authorized and one is not in src/mcpworks_api/core/mcp_proxy.py
+- [ ] T035 [P] [US5] Integration test: register two OAuth servers, authorize one, verify independent token lifecycle in tests/unit/test_mcp_oauth_multi.py
+
+**Checkpoint**: Namespace with N OAuth servers, each with independent auth state
+
+---
+
+## Phase 8: Authorization Code Fallback (Cross-Cutting)
+
+**Purpose**: Support providers that don't implement RFC 8628 device flow
+
+- [ ] T036 Implement `initiate_auth_code_flow(server, db) -> dict` — generate state token (Redis, 600s TTL), build auth_url with client_id, redirect_uri, scope, state, return AUTH_REQUIRED response with `flow: "authorization_code"` in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T037 Implement `exchange_auth_code(server, code, state, db)` — validate state from Redis, POST to token_endpoint with `grant_type=authorization_code`, encrypt + store tokens in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T038 Create callback endpoint `GET /v1/oauth/mcp-callback` — parse state, validate CSRF, call `exchange_auth_code()`, return HTML success page with informed consent disclosure in src/mcpworks_api/api/v1/mcp_oauth.py
+- [ ] T039 Register callback router in src/mcpworks_api/main.py
+- [ ] T040 Update proxy integration: if `oauth_config.flow == "authorization_code"` and no tokens, call `initiate_auth_code_flow()` instead of device flow in src/mcpworks_api/core/mcp_proxy.py
+- [ ] T041 [P] Unit test: auth code exchange, state validation, callback rendering in tests/unit/test_mcp_oauth_authcode.py
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Observability, documentation, security hardening
+
+- [ ] T042 [P] Add Prometheus metrics: `mcpworks_oauth_token_refreshes_total` [namespace, server, status], `mcpworks_oauth_device_flows_total` [namespace, server, status], `mcpworks_oauth_auth_required_total` [namespace, server, flow] in src/mcpworks_api/middleware/observability.py
+- [ ] T043 [P] Instrument all OAuth operations with Prometheus counters in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T044 [P] Add structlog events for OAuth lifecycle: device_flow_initiated, token_refreshed, token_refresh_failed, auth_code_exchanged in src/mcpworks_api/services/mcp_oauth.py
+- [ ] T045 [P] Add OAuth configuration section to docs/SELF-HOSTING.md — provider setup, device flow vs auth code, scopes reference
+- [ ] T046 [P] Add OAuth metrics to Prometheus metrics table in docs/SELF-HOSTING.md
+- [ ] T047 Security review: verify no tokens in logs (structlog scrubbing), no client_secret in describe output, encrypted storage for all secrets
+- [ ] T048 Run `ruff check` + `ruff format` + `pytest tests/unit/ -q` — full quality gate
+- [ ] T049 Run quickstart.md validation — manually test device flow and auth code scenarios
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 — device flow initiation + polling
+- **US2 (Phase 4)**: Depends on Phase 2 — can run parallel to US1
+- **US3 (Phase 5)**: Depends on US1 (needs AUTH_REQUIRED response format)
+- **US4 (Phase 6)**: Depends on Phase 2 — can run parallel to US1/US2
+- **US5 (Phase 7)**: Depends on US1 + US2 (needs working single-server flow)
+- **Auth Code Fallback (Phase 8)**: Depends on Phase 2 — can run parallel to US1-US5
+- **Polish (Phase 9)**: Depends on all above
+
+### User Story Dependencies
+
+```
+Phase 1 → Phase 2 (blocks all)
+                ├── US1 (device flow) ──┐
+                ├── US2 (refresh) ──────┤── US5 (multi-provider)
+                ├── US3 (HITL UX) ◄─ US1│
+                ├── US4 (MCP tools) ────┘
+                └── Auth Code (fallback) ── independent
+                                    ↓
+                              Phase 9 (polish)
+```
+
+### Parallel Opportunities
+
+- US1 + US2 + US4 + Auth Code Fallback can all proceed in parallel after Phase 2
+- All test tasks marked [P] can run in parallel within their phase
+- T042-T046 (polish) are all independent and parallelizable
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2 Only)
+
+1. Complete Phase 1: Setup (migration, model)
+2. Complete Phase 2: Foundational (OAuth service core)
+3. Complete Phase 3: US1 — Device flow works end-to-end
+4. Complete Phase 4: US2 — Token refresh automated
+5. **STOP and VALIDATE**: Test with real Google OAuth device flow
+6. Deploy — OAuth-protected MCP servers are usable
+
+### Incremental Delivery
+
+1. Setup + Foundational → Service exists
+2. US1 (device flow) → Users can authorize for the first time
+3. US2 (refresh) → Tokens stay valid without re-auth
+4. US3 (HITL UX) → AI agents present auth naturally
+5. US4 (MCP tools) → Self-service configuration
+6. US5 (multi-provider) → Multiple OAuth servers per namespace
+7. Auth Code Fallback → Slack, Linear, and other non-device-flow providers
+8. Polish → Metrics, docs, security review

--- a/src/mcpworks_api/api/v1/mcp_oauth.py
+++ b/src/mcpworks_api/api/v1/mcp_oauth.py
@@ -1,0 +1,93 @@
+"""OAuth callback endpoint for MCP server authorization code flow (fallback)."""
+
+import json
+
+import structlog
+from fastapi import APIRouter, Query
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+
+from mcpworks_api.core.database import get_db_context
+from mcpworks_api.core.redis import get_redis_context
+from mcpworks_api.models.namespace_mcp_server import NamespaceMcpServer
+from mcpworks_api.services.mcp_oauth import STATE_PREFIX
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/v1/oauth", tags=["oauth"])
+
+_SUCCESS_HTML = """<!DOCTYPE html>
+<html><head><title>Authorization Successful</title>
+<style>body{{font-family:system-ui;max-width:480px;margin:60px auto;padding:20px;text-align:center}}
+h1{{color:#22c55e}}p{{color:#666;line-height:1.6}}.note{{background:#fef3c7;padding:12px;border-radius:8px;margin-top:20px;font-size:0.9em}}</style>
+</head><body>
+<h1>Authorization Successful</h1>
+<p>Access granted for <strong>{provider}</strong>.</p>
+<div class="note">You are granting this namespace access to {provider}.
+All users and agents with access to this namespace can use these credentials.</div>
+<p>You can close this tab and return to your AI assistant.</p>
+</body></html>"""
+
+_ERROR_HTML = """<!DOCTYPE html>
+<html><head><title>Authorization Failed</title>
+<style>body{{font-family:system-ui;max-width:480px;margin:60px auto;padding:20px;text-align:center}}
+h1{{color:#ef4444}}p{{color:#666}}</style>
+</head><body>
+<h1>Authorization Failed</h1>
+<p>{message}</p>
+</body></html>"""
+
+
+@router.get("/mcp-callback")
+async def mcp_oauth_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+) -> HTMLResponse:
+    async with get_redis_context() as redis:
+        raw = await redis.get(f"{STATE_PREFIX}:{state}")
+        if raw:
+            await redis.delete(f"{STATE_PREFIX}:{state}")
+
+    if not raw:
+        return HTMLResponse(
+            _ERROR_HTML.format(message="Invalid or expired authorization state. Please retry."),
+            status_code=400,
+        )
+
+    state_data = json.loads(raw)
+    namespace_id = state_data["namespace_id"]
+    server_name = state_data["server_name"]
+
+    async with get_db_context() as db:
+        stmt = select(NamespaceMcpServer).where(
+            NamespaceMcpServer.namespace_id == namespace_id,
+            NamespaceMcpServer.name == server_name,
+        )
+        result = await db.execute(stmt)
+        server = result.scalar_one_or_none()
+
+        if not server:
+            return HTMLResponse(
+                _ERROR_HTML.format(message=f"MCP server '{server_name}' not found."),
+                status_code=404,
+            )
+
+        from mcpworks_api.config import get_settings
+        from mcpworks_api.services.mcp_oauth import exchange_auth_code
+
+        settings = get_settings()
+        redirect_uri = f"{settings.base_scheme}://api.{settings.base_domain}/v1/oauth/mcp-callback"
+
+        success = await exchange_auth_code(server, code, redirect_uri, db)
+        if not success:
+            return HTMLResponse(
+                _ERROR_HTML.format(message="Token exchange failed. Please retry."),
+                status_code=500,
+            )
+
+    logger.info(
+        "oauth_mcp_callback_success",
+        namespace_id=namespace_id,
+        server=server_name,
+    )
+    return HTMLResponse(_SUCCESS_HTML.format(provider=server_name))

--- a/src/mcpworks_api/core/mcp_proxy.py
+++ b/src/mcpworks_api/core/mcp_proxy.py
@@ -62,7 +62,59 @@ async def proxy_mcp_call(
     settings.update(server.settings or {})
 
     headers = None
-    if server.headers_encrypted:
+    if server.auth_type == "oauth2":
+        try:
+            from mcpworks_api.services.mcp_oauth import get_oauth_headers, get_oauth_status
+
+            oauth_status = get_oauth_status(server)
+            if oauth_status in ("not_configured", "pending_authorization", "expired"):
+                from mcpworks_api.services.mcp_oauth import (
+                    initiate_auth_code_flow,
+                    initiate_device_flow,
+                )
+
+                config_raw = None
+                if server.oauth_config_encrypted:
+                    from mcpworks_api.services.mcp_oauth import decrypt_oauth_config
+
+                    config_raw = decrypt_oauth_config(server)
+
+                flow = (config_raw or {}).get("flow", "device")
+                if flow == "device":
+                    auth_response = await initiate_device_flow(server)
+                    import asyncio as _aio
+
+                    from mcpworks_api.tasks.device_flow_poller import poll_device_code
+
+                    _aio.create_task(poll_device_code(ctx.namespace_id, server_name))
+                else:
+                    from mcpworks_api.config import get_settings
+
+                    s = get_settings()
+                    redirect_uri = f"{s.base_scheme}://api.{s.base_domain}/v1/oauth/mcp-callback"
+                    auth_response = await initiate_auth_code_flow(server, redirect_uri)
+
+                return ProxyResult(result=auth_response, error_type="AuthRequired")
+
+            oauth_headers = await get_oauth_headers(server, db)
+            if oauth_headers is None:
+                from mcpworks_api.services.mcp_oauth import initiate_device_flow
+
+                auth_response = await initiate_device_flow(server)
+                import asyncio as _aio2
+
+                from mcpworks_api.tasks.device_flow_poller import poll_device_code
+
+                _aio2.create_task(poll_device_code(ctx.namespace_id, server_name))
+                return ProxyResult(result=auth_response, error_type="AuthRequired")
+            headers = oauth_headers
+        except Exception:
+            logger.exception("oauth_header_resolution_failed", server=server_name)
+            return ProxyResult(
+                error=f"Failed to resolve OAuth credentials for MCP server '{server_name}'",
+                error_type="OAuthError",
+            )
+    elif server.headers_encrypted:
         try:
             headers = decrypt_value(server.headers_encrypted, server.headers_dek_encrypted)
         except Exception:

--- a/src/mcpworks_api/main.py
+++ b/src/mcpworks_api/main.py
@@ -241,6 +241,7 @@ def create_app() -> FastAPI:
     # Include routers
     app.include_router(v1_router)
 
+    from mcpworks_api.api.v1.mcp_oauth import router as mcp_oauth_router
     from mcpworks_api.api.v1.mcp_proxy import router as mcp_proxy_router
     from mcpworks_api.api.v1.public_chat import router as public_chat_router
     from mcpworks_api.api.v1.scratchpad_view import router as scratchpad_view_router
@@ -250,6 +251,7 @@ def create_app() -> FastAPI:
     app.include_router(webhook_router)
     app.include_router(public_chat_router)
     app.include_router(mcp_proxy_router)
+    app.include_router(mcp_oauth_router)
 
     # 015: Path-based agent sub-routes (/mcp/agent/{ns}/webhook, /chat, /view)
     from mcpworks_api.api.v1.agent_path_routes import router as agent_path_router

--- a/src/mcpworks_api/mcp/create_handler.py
+++ b/src/mcpworks_api/mcp/create_handler.py
@@ -2773,6 +2773,8 @@ class CreateMCPHandler:
         headers: dict | None = None,
         command: str | None = None,
         args: list | None = None,
+        auth_type: str = "bearer",
+        oauth_config: dict | None = None,
     ) -> MCPToolResult:
         from mcpworks_api.services.mcp_server import McpServerService
 
@@ -2787,22 +2789,21 @@ class CreateMCPHandler:
             headers=headers,
             command=command,
             args=args,
+            auth_type=auth_type,
+            oauth_config=oauth_config,
         )
-        return MCPToolResult(
-            content=[
-                MCPContent(
-                    text=json.dumps(
-                        {
-                            "name": server.name,
-                            "url": server.url,
-                            "transport": server.transport,
-                            "tool_count": server.tool_count,
-                            "tools": [t["name"] for t in (server.tool_schemas or [])],
-                        }
-                    )
-                )
-            ]
-        )
+        result = {
+            "name": server.name,
+            "url": server.url,
+            "transport": server.transport,
+            "auth_type": server.auth_type,
+            "tool_count": server.tool_count,
+            "tools": [t["name"] for t in (server.tool_schemas or [])],
+        }
+        if server.auth_type == "oauth2":
+            result["oauth_status"] = "pending_authorization"
+            result["note"] = "OAuth configured. Call any tool to start the authorization flow."
+        return MCPToolResult(content=[MCPContent(text=json.dumps(result))])
 
     async def _remove_mcp_server(self, name: str) -> MCPToolResult:
         from mcpworks_api.services.mcp_server import McpServerService
@@ -2848,32 +2849,41 @@ class CreateMCPHandler:
         ns = await self._get_current_namespace_read()
         svc = McpServerService(self.db)
         server = await svc.get_by_name(ns.id, name)
-        return MCPToolResult(
-            content=[
-                MCPContent(
-                    text=json.dumps(
-                        {
-                            "name": server.name,
-                            "url": server.url,
-                            "transport": server.transport,
-                            "command": server.command,
-                            "args": server.command_args,
-                            "enabled": server.enabled,
-                            "tool_count": server.tool_count,
-                            "last_connected": server.last_connected_at.isoformat()
-                            if server.last_connected_at
-                            else None,
-                            "settings": server.get_settings(),
-                            "env_vars": list((server.env_vars or {}).keys()),
-                            "tools": [
-                                {"name": t["name"], "description": t.get("description", "")}
-                                for t in (server.tool_schemas or [])
-                            ],
-                        }
-                    )
-                )
-            ]
-        )
+        result = {
+            "name": server.name,
+            "url": server.url,
+            "transport": server.transport,
+            "command": server.command,
+            "args": server.command_args,
+            "enabled": server.enabled,
+            "auth_type": server.auth_type,
+            "tool_count": server.tool_count,
+            "last_connected": server.last_connected_at.isoformat()
+            if server.last_connected_at
+            else None,
+            "settings": server.get_settings(),
+            "env_vars": list((server.env_vars or {}).keys()),
+            "tools": [
+                {"name": t["name"], "description": t.get("description", "")}
+                for t in (server.tool_schemas or [])
+            ],
+        }
+        if server.auth_type == "oauth2":
+            from mcpworks_api.services.mcp_oauth import decrypt_oauth_config, get_oauth_status
+
+            result["oauth_status"] = get_oauth_status(server)
+            result["oauth_expires_at"] = (
+                server.oauth_tokens_expires_at.isoformat()
+                if server.oauth_tokens_expires_at
+                else None
+            )
+            try:
+                config = decrypt_oauth_config(server)
+                result["oauth_scopes"] = config.get("scopes", [])
+                result["oauth_flow"] = config.get("flow", "device")
+            except Exception:
+                result["oauth_scopes"] = []
+        return MCPToolResult(content=[MCPContent(text=json.dumps(result))])
 
     async def _refresh_mcp_server(self, name: str) -> MCPToolResult:
         from mcpworks_api.services.mcp_server import McpServerService

--- a/src/mcpworks_api/mcp/tool_registry.py
+++ b/src/mcpworks_api/mcp/tool_registry.py
@@ -1937,6 +1937,24 @@ MCP_SERVER_TOOLS: dict[str, ToolDef] = {
                     "items": {"type": "string"},
                     "description": "Arguments for the stdio command. Example: ['-y', '@modelcontextprotocol/server-filesystem', '/data']",
                 },
+                "auth_type": {
+                    "type": "string",
+                    "enum": ["bearer", "oauth2", "none"],
+                    "description": "Authentication type. 'bearer' (default): static token via auth_token. 'oauth2': OAuth 2.0 with device flow or authorization code. 'none': no auth headers.",
+                    "default": "bearer",
+                },
+                "oauth_config": {
+                    "type": "object",
+                    "description": (
+                        "OAuth 2.0 configuration (required when auth_type='oauth2'). "
+                        "Fields: client_id, client_secret, scopes (array), flow ('device' or 'authorization_code'), "
+                        "device_authorization_endpoint (for device flow), token_endpoint, auth_endpoint (for auth code flow). "
+                        'Example: {"client_id": "123.apps.googleusercontent.com", "client_secret": "GOCSPX-...", '
+                        '"scopes": ["https://www.googleapis.com/auth/gmail.readonly"], '
+                        '"device_authorization_endpoint": "https://oauth2.googleapis.com/device/code", '
+                        '"token_endpoint": "https://oauth2.googleapis.com/token", "flow": "device"}'
+                    ),
+                },
             },
             "required": ["name"],
         },

--- a/src/mcpworks_api/middleware/observability.py
+++ b/src/mcpworks_api/middleware/observability.py
@@ -129,6 +129,26 @@ webhook_delivery_latency_seconds = Histogram(
 
 
 # ---------------------------------------------------------------------------
+# OAuth
+# ---------------------------------------------------------------------------
+oauth_token_refreshes_total = Counter(
+    "mcpworks_oauth_token_refreshes_total",
+    "OAuth token refresh attempts",
+    ["namespace", "server", "status"],
+)
+oauth_device_flows_total = Counter(
+    "mcpworks_oauth_device_flows_total",
+    "OAuth device flow initiations",
+    ["namespace", "server", "status"],
+)
+oauth_auth_required_total = Counter(
+    "mcpworks_oauth_auth_required_total",
+    "AUTH_REQUIRED responses returned to callers",
+    ["namespace", "server", "flow"],
+)
+
+
+# ---------------------------------------------------------------------------
 # Helper functions — one-line calls from existing code paths
 # ---------------------------------------------------------------------------
 def record_agent_run(
@@ -221,3 +241,15 @@ def record_webhook_delivery(
 ) -> None:
     webhook_deliveries_total.labels(namespace=namespace, status=status).inc()
     webhook_delivery_latency_seconds.labels(namespace=namespace).observe(latency_seconds)
+
+
+def record_oauth_token_refresh(namespace: str, server: str, status: str) -> None:
+    oauth_token_refreshes_total.labels(namespace=namespace, server=server, status=status).inc()
+
+
+def record_oauth_device_flow(namespace: str, server: str, status: str) -> None:
+    oauth_device_flows_total.labels(namespace=namespace, server=server, status=status).inc()
+
+
+def record_oauth_auth_required(namespace: str, server: str, flow: str) -> None:
+    oauth_auth_required_total.labels(namespace=namespace, server=server, flow=flow).inc()

--- a/src/mcpworks_api/models/namespace_mcp_server.py
+++ b/src/mcpworks_api/models/namespace_mcp_server.py
@@ -13,9 +13,11 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 
 from mcpworks_api.models.base import Base, TimestampMixin, UUIDMixin
+
+AUTH_TYPES = ("bearer", "oauth2", "none")
 
 DEFAULT_SETTINGS = {
     "response_limit_bytes": 1048576,
@@ -55,6 +57,17 @@ class NamespaceMcpServer(Base, UUIDMixin, TimestampMixin):
         DateTime(timezone=True), nullable=True
     )
 
+    auth_type: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="bearer", server_default="bearer"
+    )
+    oauth_config_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    oauth_config_dek: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    oauth_tokens_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    oauth_tokens_dek: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    oauth_tokens_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     namespace = relationship("Namespace", back_populates="mcp_servers")
 
     __table_args__ = (
@@ -65,6 +78,12 @@ class NamespaceMcpServer(Base, UUIDMixin, TimestampMixin):
         merged = dict(DEFAULT_SETTINGS)
         merged.update(self.settings or {})
         return merged
+
+    @validates("auth_type")
+    def validate_auth_type(self, key: str, value: str) -> str:
+        if value not in AUTH_TYPES:
+            raise ValueError(f"Invalid auth_type: {value}. Must be one of: {AUTH_TYPES}")
+        return value
 
     def __repr__(self) -> str:
         return f"<NamespaceMcpServer(namespace_id={self.namespace_id}, name={self.name})>"

--- a/src/mcpworks_api/services/mcp_oauth.py
+++ b/src/mcpworks_api/services/mcp_oauth.py
@@ -119,6 +119,12 @@ async def initiate_device_flow(
     async with get_redis_context() as redis:
         await redis.set(key, json.dumps(device_state), ex=ttl)
 
+    from mcpworks_api.middleware.observability import (
+        record_oauth_auth_required,
+        record_oauth_device_flow,
+    )
+
+    record_oauth_device_flow(str(server.namespace_id), server.name, "initiated")
     logger.info(
         "oauth_device_flow_initiated",
         server=server.name,
@@ -126,6 +132,7 @@ async def initiate_device_flow(
         verification_uri=device_state["verification_uri"],
     )
 
+    record_oauth_auth_required(str(server.namespace_id), server.name, "device")
     return {
         "auth_required": True,
         "provider": server.name,
@@ -273,8 +280,14 @@ async def refresh_token_if_needed(
             if error == "invalid_grant":
                 clear_tokens(server)
                 await db.flush()
+                from mcpworks_api.middleware.observability import record_oauth_token_refresh
+
+                record_oauth_token_refresh(str(server.namespace_id), server.name, "revoked")
                 logger.warning("oauth_refresh_token_revoked", server=server.name)
                 return None
+            from mcpworks_api.middleware.observability import record_oauth_token_refresh as _rec
+
+            _rec(str(server.namespace_id), server.name, "failed")
             logger.warning("oauth_refresh_failed", server=server.name, error=error)
             return None
 
@@ -284,6 +297,9 @@ async def refresh_token_if_needed(
         encrypt_and_store_tokens(server, new_tokens)
         await db.flush()
 
+        from mcpworks_api.middleware.observability import record_oauth_token_refresh
+
+        record_oauth_token_refresh(str(server.namespace_id), server.name, "success")
         logger.info("oauth_token_refreshed", server=server.name)
         return {"Authorization": f"Bearer {new_tokens['access_token']}"}
     finally:

--- a/src/mcpworks_api/services/mcp_oauth.py
+++ b/src/mcpworks_api/services/mcp_oauth.py
@@ -1,0 +1,406 @@
+"""OAuth 2.0 token management for MCP server proxy.
+
+Supports RFC 8628 Device Authorization Flow (primary) and
+Authorization Code Flow (fallback). Tokens stored with AES-256-GCM
+envelope encryption, per-namespace scoping.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from mcpworks_api.core.encryption import decrypt_value, encrypt_value
+from mcpworks_api.core.redis import get_redis_context
+from mcpworks_api.models.namespace_mcp_server import NamespaceMcpServer
+
+logger = structlog.get_logger(__name__)
+
+REFRESH_BUFFER_SECONDS = 300
+DEVICE_CODE_PREFIX = "mcp_oauth_device"
+POLLING_PREFIX = "mcp_oauth_polling"
+REFRESH_LOCK_PREFIX = "mcp_oauth_refresh"
+REFRESH_LOCK_TTL = 30
+STATE_PREFIX = "oauth_state"
+STATE_TTL = 600
+
+
+def _redis_key(prefix: str, namespace_id: Any, server_name: str) -> str:
+    return f"{prefix}:{namespace_id}:{server_name}"
+
+
+def decrypt_oauth_config(server: NamespaceMcpServer) -> dict:
+    if not server.oauth_config_encrypted or not server.oauth_config_dek:
+        raise ValueError(f"No OAuth config for server '{server.name}'")
+    return decrypt_value(server.oauth_config_encrypted, server.oauth_config_dek)
+
+
+def decrypt_oauth_tokens(server: NamespaceMcpServer) -> dict | None:
+    if not server.oauth_tokens_encrypted or not server.oauth_tokens_dek:
+        return None
+    return decrypt_value(server.oauth_tokens_encrypted, server.oauth_tokens_dek)
+
+
+def encrypt_and_store_config(server: NamespaceMcpServer, config: dict) -> None:
+    ct, dek = encrypt_value(config)
+    server.oauth_config_encrypted = ct
+    server.oauth_config_dek = dek
+
+
+def encrypt_and_store_tokens(
+    server: NamespaceMcpServer, tokens: dict, expires_in: int | None = None
+) -> None:
+    ct, dek = encrypt_value(tokens)
+    server.oauth_tokens_encrypted = ct
+    server.oauth_tokens_dek = dek
+    if expires_in:
+        server.oauth_tokens_expires_at = datetime.now(UTC) + timedelta(seconds=expires_in)
+    elif "expires_in" in tokens:
+        server.oauth_tokens_expires_at = datetime.now(UTC) + timedelta(
+            seconds=int(tokens["expires_in"])
+        )
+
+
+def clear_tokens(server: NamespaceMcpServer) -> None:
+    server.oauth_tokens_encrypted = None
+    server.oauth_tokens_dek = None
+    server.oauth_tokens_expires_at = None
+
+
+def get_oauth_status(server: NamespaceMcpServer) -> str:
+    if server.auth_type != "oauth2":
+        return "not_configured"
+    if not server.oauth_config_encrypted:
+        return "not_configured"
+    if not server.oauth_tokens_encrypted:
+        return "pending_authorization"
+    if server.oauth_tokens_expires_at and server.oauth_tokens_expires_at < datetime.now(UTC):
+        tokens = decrypt_oauth_tokens(server)
+        if tokens and tokens.get("refresh_token"):
+            return "authorized"
+        return "expired"
+    return "authorized"
+
+
+async def initiate_device_flow(
+    server: NamespaceMcpServer,
+) -> dict:
+    active = await get_active_device_code(server)
+    if active:
+        return active
+
+    config = decrypt_oauth_config(server)
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(
+            config["device_authorization_endpoint"],
+            data={
+                "client_id": config["client_id"],
+                "scope": " ".join(config.get("scopes", [])),
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    device_state = {
+        "device_code": data["device_code"],
+        "user_code": data["user_code"],
+        "verification_uri": data.get("verification_uri") or data.get("verification_url", ""),
+        "interval": data.get("interval", 5),
+        "expires_in": data.get("expires_in", 600),
+    }
+
+    ttl = device_state["expires_in"]
+    key = _redis_key(DEVICE_CODE_PREFIX, server.namespace_id, server.name)
+    async with get_redis_context() as redis:
+        await redis.set(key, json.dumps(device_state), ex=ttl)
+
+    logger.info(
+        "oauth_device_flow_initiated",
+        server=server.name,
+        namespace=str(server.namespace_id),
+        verification_uri=device_state["verification_uri"],
+    )
+
+    return {
+        "auth_required": True,
+        "provider": server.name,
+        "verification_uri": device_state["verification_uri"],
+        "user_code": device_state["user_code"],
+        "message": (
+            f"Authorization required for {server.name}. "
+            f"Go to {device_state['verification_uri']} and enter code "
+            f"{device_state['user_code']} to grant access. "
+            "The system will detect authorization automatically — just retry after approving."
+        ),
+        "expires_in": ttl,
+        "flow": "device",
+    }
+
+
+async def get_active_device_code(server: NamespaceMcpServer) -> dict | None:
+    key = _redis_key(DEVICE_CODE_PREFIX, server.namespace_id, server.name)
+    async with get_redis_context() as redis:
+        raw = await redis.get(key)
+    if not raw:
+        return None
+    state = json.loads(raw)
+
+    poll_key = _redis_key(POLLING_PREFIX, server.namespace_id, server.name)
+    async with get_redis_context() as redis:
+        is_polling = await redis.get(poll_key)
+
+    msg_suffix = (
+        " Polling for approval is active — just retry after approving."
+        if is_polling
+        else " Enter the code and retry."
+    )
+    return {
+        "auth_required": True,
+        "provider": server.name,
+        "verification_uri": state["verification_uri"],
+        "user_code": state["user_code"],
+        "message": (
+            f"Authorization still pending for {server.name}. "
+            f"Go to {state['verification_uri']} and enter code {state['user_code']}." + msg_suffix
+        ),
+        "expires_in": state.get("expires_in", 600),
+        "flow": "device",
+    }
+
+
+async def exchange_device_code(
+    server: NamespaceMcpServer,
+    device_code: str,
+    db: AsyncSession,
+) -> bool:
+    config = decrypt_oauth_config(server)
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(
+            config["token_endpoint"],
+            data={
+                "client_id": config["client_id"],
+                "client_secret": config.get("client_secret", ""),
+                "device_code": device_code,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            },
+        )
+
+    if resp.status_code != 200:
+        data = resp.json()
+        error = data.get("error", "")
+        if error in ("authorization_pending", "slow_down"):
+            return False
+        if error == "expired_token":
+            await _clear_device_state(server)
+            return False
+        logger.warning(
+            "oauth_device_exchange_error",
+            server=server.name,
+            error=error,
+            description=data.get("error_description", ""),
+        )
+        return False
+
+    tokens = resp.json()
+    encrypt_and_store_tokens(server, tokens)
+    await db.flush()
+    await _clear_device_state(server)
+
+    logger.info(
+        "oauth_tokens_stored",
+        server=server.name,
+        namespace=str(server.namespace_id),
+    )
+    return True
+
+
+async def refresh_token_if_needed(
+    server: NamespaceMcpServer,
+    db: AsyncSession,
+) -> dict | None:
+    if not server.oauth_tokens_encrypted:
+        return None
+
+    if server.oauth_tokens_expires_at and server.oauth_tokens_expires_at > datetime.now(
+        UTC
+    ) + timedelta(seconds=REFRESH_BUFFER_SECONDS):
+        tokens = decrypt_oauth_tokens(server)
+        if tokens:
+            return {"Authorization": f"Bearer {tokens['access_token']}"}
+        return None
+
+    lock_key = _redis_key(REFRESH_LOCK_PREFIX, server.namespace_id, server.name)
+    async with get_redis_context() as redis:
+        acquired = await redis.set(lock_key, "1", nx=True, ex=REFRESH_LOCK_TTL)
+
+    if not acquired:
+        for _ in range(6):
+            await _async_sleep(0.5)
+            async with get_redis_context() as redis:
+                still_locked = await redis.get(lock_key)
+            if not still_locked:
+                break
+        tokens = decrypt_oauth_tokens(server)
+        if tokens:
+            return {"Authorization": f"Bearer {tokens['access_token']}"}
+        return None
+
+    try:
+        tokens = decrypt_oauth_tokens(server)
+        if not tokens or not tokens.get("refresh_token"):
+            return None
+
+        config = decrypt_oauth_config(server)
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(
+                config["token_endpoint"],
+                data={
+                    "client_id": config["client_id"],
+                    "client_secret": config.get("client_secret", ""),
+                    "grant_type": "refresh_token",
+                    "refresh_token": tokens["refresh_token"],
+                },
+            )
+
+        if resp.status_code != 200:
+            data = resp.json()
+            error = data.get("error", "")
+            if error == "invalid_grant":
+                clear_tokens(server)
+                await db.flush()
+                logger.warning("oauth_refresh_token_revoked", server=server.name)
+                return None
+            logger.warning("oauth_refresh_failed", server=server.name, error=error)
+            return None
+
+        new_tokens = resp.json()
+        if "refresh_token" not in new_tokens:
+            new_tokens["refresh_token"] = tokens["refresh_token"]
+        encrypt_and_store_tokens(server, new_tokens)
+        await db.flush()
+
+        logger.info("oauth_token_refreshed", server=server.name)
+        return {"Authorization": f"Bearer {new_tokens['access_token']}"}
+    finally:
+        async with get_redis_context() as redis:
+            await redis.delete(lock_key)
+
+
+async def get_oauth_headers(
+    server: NamespaceMcpServer,
+    db: AsyncSession,
+) -> dict | None:
+    if server.auth_type != "oauth2":
+        return None
+
+    status = get_oauth_status(server)
+    if status in ("not_configured", "pending_authorization"):
+        return None
+
+    headers = await refresh_token_if_needed(server, db)
+    return headers
+
+
+async def initiate_auth_code_flow(
+    server: NamespaceMcpServer,
+    redirect_uri: str,
+) -> dict:
+    import secrets
+
+    config = decrypt_oauth_config(server)
+    state_token = secrets.token_urlsafe(32)
+    state_data = {
+        "namespace_id": str(server.namespace_id),
+        "server_name": server.name,
+        "csrf": state_token,
+    }
+
+    async with get_redis_context() as redis:
+        await redis.set(
+            f"{STATE_PREFIX}:{state_token}",
+            json.dumps(state_data),
+            ex=STATE_TTL,
+        )
+
+    params = {
+        "client_id": config["client_id"],
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(config.get("scopes", [])),
+        "state": state_token,
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    from urllib.parse import urlencode
+
+    auth_url = f"{config['auth_endpoint']}?{urlencode(params)}"
+
+    return {
+        "auth_required": True,
+        "provider": server.name,
+        "auth_url": auth_url,
+        "message": (
+            f"Authorization required for {server.name}. "
+            "Open the URL in a browser to grant access, then retry."
+        ),
+        "expires_in": STATE_TTL,
+        "flow": "authorization_code",
+    }
+
+
+async def exchange_auth_code(
+    server: NamespaceMcpServer,
+    code: str,
+    redirect_uri: str,
+    db: AsyncSession,
+) -> bool:
+    config = decrypt_oauth_config(server)
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(
+            config["token_endpoint"],
+            data={
+                "client_id": config["client_id"],
+                "client_secret": config.get("client_secret", ""),
+                "code": code,
+                "grant_type": "authorization_code",
+                "redirect_uri": redirect_uri,
+            },
+        )
+
+    if resp.status_code != 200:
+        logger.warning(
+            "oauth_auth_code_exchange_failed",
+            server=server.name,
+            status=resp.status_code,
+        )
+        return False
+
+    tokens = resp.json()
+    encrypt_and_store_tokens(server, tokens)
+    await db.flush()
+
+    logger.info(
+        "oauth_tokens_stored_via_auth_code",
+        server=server.name,
+        namespace=str(server.namespace_id),
+    )
+    return True
+
+
+async def _clear_device_state(server: NamespaceMcpServer) -> None:
+    async with get_redis_context() as redis:
+        await redis.delete(
+            _redis_key(DEVICE_CODE_PREFIX, server.namespace_id, server.name),
+            _redis_key(POLLING_PREFIX, server.namespace_id, server.name),
+        )
+
+
+async def _async_sleep(seconds: float) -> None:
+    import asyncio
+
+    await asyncio.sleep(seconds)

--- a/src/mcpworks_api/services/mcp_oauth.py
+++ b/src/mcpworks_api/services/mcp_oauth.py
@@ -252,6 +252,7 @@ async def refresh_token_if_needed(
                 still_locked = await redis.get(lock_key)
             if not still_locked:
                 break
+        await db.refresh(server)
         tokens = decrypt_oauth_tokens(server)
         if tokens:
             return {"Authorization": f"Bearer {tokens['access_token']}"}

--- a/src/mcpworks_api/services/mcp_server.py
+++ b/src/mcpworks_api/services/mcp_server.py
@@ -39,6 +39,8 @@ class McpServerService:
         headers: dict[str, str] | None = None,
         command: str | None = None,
         args: list[str] | None = None,
+        auth_type: str = "bearer",
+        oauth_config: dict | None = None,
     ) -> NamespaceMcpServer:
         existing = await self._get_by_name_optional(namespace_id, name)
         if existing:
@@ -82,6 +84,11 @@ class McpServerService:
             for t in tool_schemas
         }
 
+        oauth_config_enc = None
+        oauth_config_dek_val = None
+        if auth_type == "oauth2" and oauth_config:
+            oauth_config_enc, oauth_config_dek_val = encrypt_value(oauth_config)
+
         server = NamespaceMcpServer(
             namespace_id=namespace_id,
             name=name,
@@ -97,6 +104,9 @@ class McpServerService:
             tool_schemas=tool_schemas,
             tool_count=tool_count,
             last_connected_at=datetime.now(UTC),
+            auth_type=auth_type,
+            oauth_config_encrypted=oauth_config_enc,
+            oauth_config_dek=oauth_config_dek_val,
         )
         self.db.add(server)
         await self.db.flush()

--- a/src/mcpworks_api/tasks/device_flow_poller.py
+++ b/src/mcpworks_api/tasks/device_flow_poller.py
@@ -1,0 +1,88 @@
+"""Background poller for OAuth 2.0 Device Authorization Flow (RFC 8628).
+
+Spawned as an asyncio task when a device code is issued. Polls the
+provider's token endpoint at the specified interval until the user
+approves, the code expires, or the task is cancelled.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+import structlog
+
+from mcpworks_api.core.database import get_db_context
+from mcpworks_api.core.redis import get_redis_context
+from mcpworks_api.services.mcp_oauth import (
+    DEVICE_CODE_PREFIX,
+    POLLING_PREFIX,
+    _redis_key,
+    exchange_device_code,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+async def poll_device_code(
+    namespace_id: uuid.UUID,
+    server_name: str,
+) -> None:
+    """Poll for device code approval. Runs as a background task.
+
+    Exits when: user approves, code expires, or task is cancelled.
+    """
+    poll_key = _redis_key(POLLING_PREFIX, namespace_id, server_name)
+    device_key = _redis_key(DEVICE_CODE_PREFIX, namespace_id, server_name)
+
+    async with get_redis_context() as redis:
+        already_polling = await redis.set(poll_key, "1", nx=True, ex=660)
+    if not already_polling:
+        logger.debug("device_poller_already_active", server=server_name)
+        return
+
+    logger.info("device_poller_started", server=server_name, namespace=str(namespace_id))
+
+    try:
+        interval = 5
+        while True:
+            await asyncio.sleep(interval)
+
+            async with get_redis_context() as redis:
+                raw = await redis.get(device_key)
+            if not raw:
+                logger.info("device_poller_code_expired", server=server_name)
+                break
+
+            state = json.loads(raw)
+            device_code = state["device_code"]
+            interval = state.get("interval", 5)
+
+            from sqlalchemy import select
+
+            from mcpworks_api.models.namespace_mcp_server import NamespaceMcpServer
+
+            async with get_db_context() as db:
+                stmt = select(NamespaceMcpServer).where(
+                    NamespaceMcpServer.namespace_id == namespace_id,
+                    NamespaceMcpServer.name == server_name,
+                )
+                result = await db.execute(stmt)
+                server = result.scalar_one_or_none()
+                if not server:
+                    logger.warning("device_poller_server_gone", server=server_name)
+                    break
+
+                success = await exchange_device_code(server, device_code, db)
+                if success:
+                    logger.info("device_poller_authorized", server=server_name)
+                    break
+
+    except asyncio.CancelledError:
+        logger.info("device_poller_cancelled", server=server_name)
+    except Exception:
+        logger.exception("device_poller_error", server=server_name)
+    finally:
+        async with get_redis_context() as redis:
+            await redis.delete(poll_key)


### PR DESCRIPTION
## Summary

- **OAuth 2.0 Device Authorization Flow (RFC 8628)** as primary auth method for external MCP servers — no callback URL needed, "enter this code" UX fits agentic platforms
- **Authorization Code Flow** as fallback for providers that don't support device flow (Slack, Linear)
- **Silent token refresh** with proactive expiry check + Redis lock for concurrent safety
- **HITL auth surfacing** — structured `AUTH_REQUIRED` response that AI agents can present naturally ("Go to google.com/device and enter code WDJB-MJHT")
- **Background device code poller** — asyncio task polls provider until user approves or code expires
- **Full MCP tool integration** — `add_mcp_server` accepts `auth_type="oauth2"` + `oauth_config`, `describe_mcp_server` shows OAuth status
- **Callback endpoint** at `/v1/oauth/mcp-callback` with informed consent disclosure HTML
- **3 new Prometheus metrics**: `mcpworks_oauth_token_refreshes_total`, `mcpworks_oauth_device_flows_total`, `mcpworks_oauth_auth_required_total`
- **Spec-kit artifacts**: spec.md, research.md (7 decisions), data-model.md, quickstart.md, plan.md, tasks.md (49 tasks)

Tokens are per-namespace (not per-user), encrypted at rest with AES-256-GCM envelope encryption. Designed for the use case: Google Workspace MCP server registered on a namespace, authenticated via OAuth, callable from code-mode sandbox.

## Test plan

- [x] `pytest tests/unit/ -q` — 649 passed, 2 skipped
- [x] `ruff check src/` + `ruff format --check src/` — clean
- [ ] Run `alembic upgrade head` — adds 6 columns to `namespace_mcp_servers`
- [ ] Register OAuth MCP server via `add_mcp_server(auth_type="oauth2", oauth_config={...})`
- [ ] Trigger tool call → verify `AUTH_REQUIRED` response with device code
- [ ] Complete device flow → verify tokens stored and subsequent calls succeed
- [ ] Wait for token expiry → verify silent refresh
- [ ] Test auth code fallback via `/v1/oauth/mcp-callback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)