### PR TITLE
Orchestration pipeline observability (PROBLEM-029)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ specs/                  # Speckit artifacts per feature
 - PostgreSQL 15+ (new trust_score columns on `agents` table) (024-trust-scoring-and-compliance)
 - Python 3.11+ (existing codebase) + FastAPI 0.109+ (existing), Authlib 1.3+ (existing), httpx (existing), SQLAlchemy 2.0+ (existing) (026-oauth-mcp-proxy)
 - PostgreSQL 15+ (5 new columns on `namespace_mcp_servers`), Redis 7+ (ephemeral device flow state) (026-oauth-mcp-proxy)
+- Python 3.11+ + FastAPI 0.109+, SQLAlchemy 2.0+ (async), Pydantic v2, structlog, croniter (027-orchestration-observability)
+- PostgreSQL 15+ (new `schedule_fires` table, schema changes to `agent_runs` and `agent_tool_calls`) (027-orchestration-observability)
 
 ## Recent Changes
 - 001-api-gateway-mvp: Added Python 3.11+ + FastAPI 0.109+, SQLAlchemy 2.0+ (async), Pydantic v2, httpx, PyJWT, argon2-cffi, stripe

--- a/alembic/versions/20260414_000001_add_orchestration_observability.py
+++ b/alembic/versions/20260414_000001_add_orchestration_observability.py
@@ -1,0 +1,130 @@
+"""Add orchestration observability: extend agent_runs/agent_tool_calls, create schedule_fires.
+
+Revision ID: 20260414_000001
+Revises: 20260413_000001
+Create Date: 2026-04-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20260414_000001"
+down_revision = "20260413_000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_runs",
+        sa.Column("outcome", sa.String(20), nullable=True),
+    )
+    op.add_column(
+        "agent_runs",
+        sa.Column("orchestration_mode", sa.String(20), nullable=True),
+    )
+    op.add_column(
+        "agent_runs",
+        sa.Column("limits_consumed", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        "agent_runs",
+        sa.Column("limits_configured", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        "agent_runs",
+        sa.Column(
+            "schedule_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("agent_schedules.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "agent_runs",
+        sa.Column("functions_called_count", sa.Integer(), nullable=True),
+    )
+    op.create_index("ix_agent_runs_outcome", "agent_runs", ["outcome"])
+    op.create_index("ix_agent_runs_schedule", "agent_runs", ["schedule_id"])
+
+    op.add_column(
+        "agent_tool_calls",
+        sa.Column(
+            "decision_type",
+            sa.String(20),
+            nullable=False,
+            server_default="call",
+        ),
+    )
+    op.add_column(
+        "agent_tool_calls",
+        sa.Column("reason_category", sa.String(50), nullable=True),
+    )
+
+    op.create_table(
+        "schedule_fires",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("schedule_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "fired_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("agent_run_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("error_detail", sa.String(500), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["schedule_id"],
+            ["agent_schedules.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agents.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_run_id"],
+            ["agent_runs.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_schedule_fires_schedule_fired",
+        "schedule_fires",
+        ["schedule_id", "fired_at"],
+    )
+    op.create_index(
+        "ix_schedule_fires_agent_fired",
+        "schedule_fires",
+        ["agent_id", "fired_at"],
+    )
+    op.create_index(
+        "ix_schedule_fires_created",
+        "schedule_fires",
+        ["created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("schedule_fires")
+    op.drop_column("agent_tool_calls", "reason_category")
+    op.drop_column("agent_tool_calls", "decision_type")
+    op.drop_index("ix_agent_runs_schedule", table_name="agent_runs")
+    op.drop_index("ix_agent_runs_outcome", table_name="agent_runs")
+    op.drop_column("agent_runs", "functions_called_count")
+    op.drop_column("agent_runs", "schedule_id")
+    op.drop_column("agent_runs", "limits_configured")
+    op.drop_column("agent_runs", "limits_consumed")
+    op.drop_column("agent_runs", "orchestration_mode")
+    op.drop_column("agent_runs", "outcome")

--- a/specs/027-orchestration-observability/checklists/requirements.md
+++ b/specs/027-orchestration-observability/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Orchestration Pipeline Observability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec references existing platform concepts (orchestration modes, telemetry webhooks, MCP tools) by their user-facing names without specifying implementation details.
+- Assumptions section documents reasonable defaults for retention periods and data scope.

--- a/specs/027-orchestration-observability/contracts/rest-api.md
+++ b/specs/027-orchestration-observability/contracts/rest-api.md
@@ -1,0 +1,226 @@
+# REST API Contracts: Orchestration Pipeline Observability
+
+## Endpoints
+
+### GET /v1/agents/{agent_id}/runs
+
+List orchestration runs for an agent.
+
+**Query Parameters**:
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `trigger_type` | string | no | — | Filter: cron, webhook, manual, ai, heartbeat |
+| `outcome` | string | no | — | Filter: completed, no_action, limit_hit, failed, timeout, cancelled |
+| `since` | datetime | no | — | Only runs after this timestamp |
+| `until` | datetime | no | — | Only runs before this timestamp |
+| `limit` | int | no | 20 | Max results (1-100) |
+| `offset` | int | no | 0 | Pagination offset |
+
+**Response 200**:
+```json
+{
+  "runs": [
+    {
+      "id": "uuid",
+      "agent_id": "uuid",
+      "trigger_type": "cron",
+      "trigger_detail": "orchestration:cron",
+      "orchestration_mode": "run_then_reason",
+      "schedule_id": "uuid | null",
+      "outcome": "completed",
+      "status": "completed",
+      "functions_called_count": 3,
+      "started_at": "2026-04-14T10:00:00Z",
+      "completed_at": "2026-04-14T10:00:45Z",
+      "duration_ms": 45000,
+      "error": null
+    }
+  ],
+  "total": 142,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+### GET /v1/agents/{agent_id}/runs/{run_id}
+
+Get full detail of a single orchestration run.
+
+**Response 200**:
+```json
+{
+  "id": "uuid",
+  "agent_id": "uuid",
+  "trigger_type": "cron",
+  "trigger_detail": "orchestration:cron",
+  "orchestration_mode": "run_then_reason",
+  "schedule_id": "uuid | null",
+  "outcome": "completed",
+  "status": "completed",
+  "started_at": "2026-04-14T10:00:00Z",
+  "completed_at": "2026-04-14T10:00:45Z",
+  "duration_ms": 45000,
+  "functions_called_count": 3,
+  "limits_consumed": {
+    "iterations": 4,
+    "ai_tokens": 12500,
+    "functions_called": 3,
+    "execution_seconds": 45
+  },
+  "limits_configured": {
+    "iterations": 25,
+    "ai_tokens": 1000000,
+    "functions_called": 25,
+    "execution_seconds": 300
+  },
+  "error": null,
+  "steps": [
+    {
+      "sequence_number": 1,
+      "decision_type": "call",
+      "tool_name": "find-shareable-news",
+      "reason_category": "success",
+      "duration_ms": 5200,
+      "status": "success"
+    },
+    {
+      "sequence_number": 2,
+      "decision_type": "call",
+      "tool_name": "post-to-bluesky",
+      "reason_category": "success",
+      "duration_ms": 1200,
+      "status": "success"
+    },
+    {
+      "sequence_number": 3,
+      "decision_type": "skip",
+      "tool_name": "send-discord-report",
+      "reason_category": "quality_threshold_not_met",
+      "duration_ms": null,
+      "status": "success"
+    }
+  ]
+}
+```
+
+### GET /v1/schedules/{schedule_id}/fires
+
+List fire history for a schedule.
+
+**Query Parameters**:
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `status` | string | no | — | Filter: started, error, skipped |
+| `since` | datetime | no | — | Only fires after this timestamp |
+| `limit` | int | no | 20 | Max results (1-100) |
+| `offset` | int | no | 0 | Pagination offset |
+
+**Response 200**:
+```json
+{
+  "fires": [
+    {
+      "id": "uuid",
+      "schedule_id": "uuid",
+      "agent_id": "uuid",
+      "fired_at": "2026-04-14T10:00:00Z",
+      "status": "started",
+      "agent_run_id": "uuid",
+      "error_detail": null
+    }
+  ],
+  "total": 48,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+## MCP Tool Contracts
+
+### list_orchestration_runs
+
+**Description** (≤20 tokens): List orchestration runs for an agent with optional filters.
+
+**Input Schema**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "agent": {"type": "string", "description": "Agent name"},
+    "trigger_type": {"type": "string", "enum": ["cron", "webhook", "manual", "ai", "heartbeat"]},
+    "outcome": {"type": "string", "enum": ["completed", "no_action", "limit_hit", "failed", "timeout", "cancelled"]},
+    "limit": {"type": "integer", "default": 10, "minimum": 1, "maximum": 50}
+  },
+  "required": ["agent"]
+}
+```
+
+**Output**: Summary list matching REST `/runs` response format.
+
+### describe_orchestration_run
+
+**Description** (≤20 tokens): Get full detail of an orchestration run including steps and limits.
+
+**Input Schema**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "run_id": {"type": "string", "description": "Orchestration run ID"}
+  },
+  "required": ["run_id"]
+}
+```
+
+**Output**: Full run detail matching REST `/runs/{run_id}` response format.
+
+### list_schedule_fires
+
+**Description** (≤20 tokens): List fire history for a cron schedule.
+
+**Input Schema**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "agent": {"type": "string", "description": "Agent name"},
+    "schedule_id": {"type": "string", "description": "Schedule ID"},
+    "status": {"type": "string", "enum": ["started", "error", "skipped"]},
+    "limit": {"type": "integer", "default": 10, "minimum": 1, "maximum": 50}
+  },
+  "required": ["agent"]
+}
+```
+
+**Output**: Fire history list matching REST `/fires` response format.
+
+## Telemetry Webhook Event
+
+### Event Type: `orchestration_run`
+
+Added to `telemetry_config` as opt-in:
+```json
+{
+  "events": ["tool_call", "orchestration_run"]
+}
+```
+
+**Payload**:
+```json
+{
+  "event_type": "orchestration_run",
+  "timestamp": "2026-04-14T10:00:45Z",
+  "namespace": "mcpworkssocial",
+  "agent": "social-bot",
+  "run_id": "uuid",
+  "trigger_type": "cron",
+  "orchestration_mode": "run_then_reason",
+  "outcome": "completed",
+  "duration_ms": 45000,
+  "functions_called_count": 3,
+  "steps_count": 4,
+  "limits_consumed": {"iterations": 4, "ai_tokens": 12500, "functions_called": 3, "execution_seconds": 45},
+  "limits_configured": {"iterations": 25, "ai_tokens": 1000000, "functions_called": 25, "execution_seconds": 300},
+  "error": null
+}
+```

--- a/specs/027-orchestration-observability/data-model.md
+++ b/specs/027-orchestration-observability/data-model.md
@@ -1,0 +1,100 @@
+# Data Model: Orchestration Pipeline Observability
+
+**Date**: 2026-04-14
+**Branch**: `027-orchestration-observability`
+
+## Entity Changes
+
+### 1. AgentRun (EXTEND existing `agent_runs` table)
+
+Existing columns preserved. New columns:
+
+| Column | Type | Nullable | Default | Purpose |
+|--------|------|----------|---------|---------|
+| `orchestration_mode` | `String(20)` | YES | `NULL` | Which mode was used (direct, reason_first, run_then_reason, procedure) |
+| `outcome` | `String(20)` | YES | `NULL` | Structured outcome: completed, no_action, limit_hit, error, cancelled, timeout |
+| `limits_consumed` | `JSONB` | YES | `NULL` | `{"iterations": N, "ai_tokens": N, "functions_called": N, "execution_seconds": N}` |
+| `limits_configured` | `JSONB` | YES | `NULL` | Same structure — the limits that were in effect for this run |
+| `schedule_id` | `UUID FK → agent_schedules.id` | YES | `NULL` | Which schedule triggered this run (if cron-triggered) |
+| `functions_called_count` | `Integer` | YES | `NULL` | Count of functions actually called (faster than counting tool_calls) |
+
+**Status values** (extend `RUN_STATUSES`): `running`, `completed`, `failed`, `timeout`, `no_action`, `limit_hit`, `cancelled`
+
+**Indexes**:
+- `ix_agent_runs_outcome` on `(outcome)` — for filtering by outcome type
+- `ix_agent_runs_schedule` on `(schedule_id)` — for fire→run correlation
+
+**Relationships**:
+- `schedule_fires` ← `ScheduleFire.agent_run_id` (one run can have one fire; one fire produces zero or one run)
+
+### 2. AgentToolCall (EXTEND existing `agent_tool_calls` table)
+
+Existing columns preserved. New columns:
+
+| Column | Type | Nullable | Default | Purpose |
+|--------|------|----------|---------|---------|
+| `decision_type` | `String(20)` | NO | `'call'` | One of: `call`, `skip`, `no_action`, `limit_check` |
+| `reason_category` | `String(50)` | YES | `NULL` | Enum: `success`, `error`, `quality_threshold_not_met`, `no_matching_data`, `limit_reached`, `rate_limited`, `access_denied`, `timeout`, `not_applicable` |
+
+**Default `'call'`** ensures backward compatibility — existing rows (which are all function calls) get the correct decision_type without backfill.
+
+### 3. ScheduleFire (NEW `schedule_fires` table)
+
+| Column | Type | Nullable | Default | Purpose |
+|--------|------|----------|---------|---------|
+| `id` | `UUID` PK | NO | `uuid4()` | UUIDMixin |
+| `schedule_id` | `UUID FK → agent_schedules.id` | NO | — | Which schedule fired |
+| `agent_id` | `UUID FK → agents.id` | NO | — | Denormalized for faster queries without join |
+| `fired_at` | `DateTime(tz)` | NO | `now()` | When the fire occurred |
+| `status` | `String(20)` | NO | — | `started`, `error`, `skipped` |
+| `agent_run_id` | `UUID FK → agent_runs.id` | YES | `NULL` | The run this fire produced (NULL if fire failed to start a run) |
+| `error_detail` | `String(500)` | YES | `NULL` | Why the fire failed (e.g., "agent stopped", "function not found") |
+| `created_at` | `DateTime(tz)` | NO | `now()` | UUIDMixin |
+
+**Indexes**:
+- `ix_schedule_fires_schedule_fired` on `(schedule_id, fired_at)` — primary query path
+- `ix_schedule_fires_agent_fired` on `(agent_id, fired_at)` — for agent-level fire listing
+- `ix_schedule_fires_created` on `(created_at)` — for retention pruning
+
+**Relationships**:
+- `schedule` → `AgentSchedule` (many fires per schedule)
+- `agent_run` → `AgentRun` (optional, one-to-one)
+
+## State Transitions
+
+### AgentRun Status
+
+```
+running → completed     (normal completion with function calls)
+running → no_action     (AI decided not to call any functions)
+running → limit_hit     (max_iterations, max_ai_tokens, etc. exceeded)
+running → failed        (unrecoverable error during orchestration)
+running → timeout       (max_execution_seconds exceeded)
+running → cancelled     (agent stopped mid-run)
+```
+
+### ScheduleFire Status
+
+```
+started     (fire initiated, run in progress or completed)
+error       (fire failed before a run could start)
+skipped     (fire suppressed — e.g., schedule disabled mid-fire, future use)
+```
+
+## Retention
+
+| Table | Default Retention | Pruning Strategy |
+|-------|-------------------|------------------|
+| `agent_runs` | 30 days | DELETE WHERE created_at < now() - interval '30 days' |
+| `agent_tool_calls` | Cascades with agent_runs | ON DELETE CASCADE |
+| `schedule_fires` | 90 days | DELETE WHERE created_at < now() - interval '90 days' |
+
+Pruning runs as a periodic background task (daily at low-traffic hours).
+
+## Migration Notes
+
+- `AgentRun` new columns are all nullable — zero-downtime migration, no backfill required
+- `AgentToolCall.decision_type` has server_default `'call'` — existing rows get correct value
+- `AgentToolCall.reason_category` is nullable — existing rows remain NULL (interpreted as "not categorized")
+- `ScheduleFire` is a new table — no data migration
+- `RUN_STATUSES` tuple extended in Python model; no DB constraint (validated in application)

--- a/specs/027-orchestration-observability/plan.md
+++ b/specs/027-orchestration-observability/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: Orchestration Pipeline Observability
+
+**Branch**: `027-orchestration-observability` | **Date**: 2026-04-14 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/027-orchestration-observability/spec.md`
+
+## Summary
+
+Make the orchestration pipeline observable end-to-end by extending the existing `AgentRun` model with structured outcome/limit tracking, adding a `ScheduleFire` table for cron fire history, enriching `AgentToolCall` with decision-type semantics, exposing all data via MCP tools and REST endpoints, and optionally pushing run-completion events through the existing telemetry webhook.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: FastAPI 0.109+, SQLAlchemy 2.0+ (async), Pydantic v2, structlog, croniter
+**Storage**: PostgreSQL 15+ (new `schedule_fires` table, schema changes to `agent_runs` and `agent_tool_calls`)
+**Testing**: pytest (unit tests in `tests/unit/`, integration tests in `tests/integration/`)
+**Target Platform**: Linux server (Docker container on server0.pop11)
+**Project Type**: single (backend API)
+**Performance Goals**: List queries p95 < 200ms for 1000 runs; describe queries p95 < 100ms
+**Constraints**: Structured decision logs only (no free-text AI summaries) to prevent PII exposure; fire-and-forget webhook delivery
+**Scale/Scope**: ~500 runs/day per active agent, 30-day run retention, 90-day fire retention
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-First Development | PASS | Spec complete with clarifications |
+| II. Token Efficiency & Streaming | PASS | MCP tools return references + progressive disclosure; list endpoints return summaries, describe returns full detail |
+| III. Transaction Safety & Security | PASS | No credit operations; PII prevention via structured decision logs (no free-text); access scoped to namespace owner |
+| IV. Provider Abstraction & Observability | PASS | This IS the observability feature; builds on existing structlog + Prometheus infrastructure |
+| V. API Contracts & Test Coverage | PASS | New MCP tools follow existing patterns; unit tests for models/services, integration tests for endpoints |
+
+No violations. No complexity justification needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/027-orchestration-observability/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/mcpworks_api/
+├── models/
+│   ├── agent.py                    # AgentRun schema changes (outcome, limits_consumed, limits_configured)
+│   └── schedule_fire.py            # NEW: ScheduleFire model
+├── schemas/
+│   └── observability.py            # NEW: Pydantic response schemas for runs/fires
+├── services/
+│   └── observability_service.py    # NEW: Query service for runs, fires, steps
+├── routers/
+│   └── observability.py            # NEW: REST endpoints (v1)
+├── mcp/
+│   ├── tool_registry.py            # New tool definitions
+│   └── create_handler.py           # New tool handlers
+├── tasks/
+│   ├── orchestrator.py             # Emit structured decision steps, set outcome/limits
+│   └── scheduler.py                # Record ScheduleFire on every cron fire
+└── services/
+    └── telemetry.py                # Add orchestration_run_completed event type
+
+alembic/versions/
+└── YYYYMMDD_add_orchestration_observability.py  # Migration
+
+tests/unit/
+├── test_schedule_fire_model.py
+├── test_observability_service.py
+└── test_observability_schemas.py
+```
+
+**Structure Decision**: Single backend project. All changes are within the existing `src/mcpworks_api/` tree. One new model file (`schedule_fire.py`), one new service, one new router, extensions to existing orchestrator/scheduler/telemetry. Follows the established pattern from 025-observability-excellence.
+
+## Constitution Check — Post-Design
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-First Development | PASS | Spec → Plan → Tasks flow followed |
+| II. Token Efficiency & Streaming | PASS | MCP tool descriptions ≤20 tokens; list returns summaries (id, outcome, duration), describe returns full steps. Progressive disclosure pattern. |
+| III. Transaction Safety & Security | PASS | No credit/billing changes. PII prevented by design: decision_type + reason_category enums, no free-text. Access via existing namespace auth. |
+| IV. Provider Abstraction & Observability | PASS | Extends existing Prometheus metrics and structlog. New ScheduleFire adds the missing fire-level observability. |
+| V. API Contracts & Test Coverage | PASS | 3 new MCP tools, 3 new REST endpoints, all with defined contracts. Unit tests for models/service, integration tests for endpoints. |
+
+No violations. No complexity tracking entries needed.

--- a/specs/027-orchestration-observability/quickstart.md
+++ b/specs/027-orchestration-observability/quickstart.md
@@ -1,0 +1,52 @@
+# Quickstart: Orchestration Pipeline Observability
+
+## What This Feature Does
+
+Makes the orchestration pipeline visible end-to-end. After this feature ships, namespace owners can:
+
+1. **See every orchestration run** — what triggered it, what the agent decided, which functions were called, whether limits were hit, and the final outcome.
+2. **See every cron fire** — when it fired, whether it produced a run, and why it failed if it didn't.
+3. **Trace any function execution** back to the run and trigger that caused it.
+4. **Receive webhook notifications** when runs complete (opt-in).
+
+## Key Implementation Decisions
+
+- **Extend existing models** (AgentRun, AgentToolCall) rather than creating new entities. The `agent_run_id` FK on Execution already exists.
+- **Structured decision logs only** — no free-text AI summaries to prevent PII exposure. Steps record decision_type + reason_category enums.
+- **New `schedule_fires` table** — each cron fire gets a row regardless of whether it produces a run.
+- **No concurrent run gating** — overlapping runs are recorded faithfully for diagnosis.
+
+## Implementation Order
+
+1. **Migration** — Add columns to `agent_runs`, `agent_tool_calls`; create `schedule_fires` table
+2. **Models** — Extend AgentRun/AgentToolCall, create ScheduleFire model
+3. **Orchestrator changes** — Emit structured steps, classify outcomes, persist limits
+4. **Scheduler changes** — Record ScheduleFire on every cron fire
+5. **Service layer** — ObservabilityService for queries
+6. **MCP tools** — list_orchestration_runs, describe_orchestration_run, list_schedule_fires
+7. **REST endpoints** — /v1/agents/{id}/runs, /v1/schedules/{id}/fires
+8. **Telemetry webhook** — orchestration_run event type
+9. **Retention** — Background pruning task
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `src/mcpworks_api/models/agent.py` | Extend AgentRun (outcome, limits, schedule_id), extend RUN_STATUSES |
+| `src/mcpworks_api/models/agent_tool_call.py` | Add decision_type, reason_category columns |
+| `src/mcpworks_api/models/schedule_fire.py` | NEW — ScheduleFire model |
+| `src/mcpworks_api/tasks/orchestrator.py` | Classify outcome, emit structured steps, persist limits |
+| `src/mcpworks_api/tasks/scheduler.py` | Record ScheduleFire on every fire |
+| `src/mcpworks_api/services/observability_service.py` | NEW — query service |
+| `src/mcpworks_api/schemas/observability.py` | NEW — Pydantic response schemas |
+| `src/mcpworks_api/routers/observability.py` | NEW — REST endpoints |
+| `src/mcpworks_api/mcp/tool_registry.py` | Tool definitions |
+| `src/mcpworks_api/mcp/create_handler.py` | Tool handlers |
+| `src/mcpworks_api/services/telemetry.py` | orchestration_run event type |
+| `alembic/versions/` | Migration |
+
+## Testing Strategy
+
+- **Unit tests**: Model validation (outcome values, decision_type defaults), service query logic (filters, pagination), schema serialization
+- **Integration tests**: End-to-end: trigger orchestration → query runs → verify steps. Fire schedule → query fire history → verify run correlation
+- **Manual verification**: Deploy, trigger mcpworkssocial cron, query via MCP tools, verify fire→run→steps chain

--- a/specs/027-orchestration-observability/research.md
+++ b/specs/027-orchestration-observability/research.md
@@ -1,0 +1,80 @@
+# Research: Orchestration Pipeline Observability
+
+**Date**: 2026-04-14
+**Branch**: `027-orchestration-observability`
+
+## R1: Existing AgentRun Model — Extend vs Replace
+
+**Decision**: Extend the existing `AgentRun` model with new columns.
+
+**Rationale**: `AgentRun` already has the core structure (agent_id, trigger_type, trigger_detail, status, started_at, completed_at, duration_ms, result_summary, error) and is persisted by the orchestrator in `_record_run()`. The `agent_run_id` FK on `Execution` already exists (added in 025-observability-excellence). Adding columns for outcome classification, limits consumed/configured, and orchestration_mode is lower risk than creating a parallel entity.
+
+**Alternatives considered**:
+- New `OrchestrationRun` table: Would require migrating existing `AgentRun` data, updating all FK references, and duplicating the recording logic in orchestrator.py. No benefit over extending.
+- JSONB metadata column: Would avoid schema changes but lose query filtering capability on outcome/limits.
+
+## R2: Structured Decision Log — Where to Store
+
+**Decision**: Extend the existing `AgentToolCall` model with a `decision_type` and `reason_category` column. The `AgentToolCall` table already records per-step data within a run (sequence_number, tool_name, status). Adding two enum columns captures the decision semantics without a new table.
+
+**Rationale**: `AgentToolCall` is already ordered by sequence_number within an AgentRun and captures tool invocations. Steps where the agent decides NOT to call a function are currently not recorded — adding a row with `decision_type='skip'` and `reason_category='quality_threshold_not_met'` fills this gap. Steps where a function IS called already have a row; we just add `decision_type='call'` (defaulting existing rows).
+
+**Alternatives considered**:
+- Separate `OrchestrationStep` table: Additional join, additional migration, no benefit over extending AgentToolCall which already serves this purpose.
+- JSONB array on AgentRun: Loses per-step queryability, harder to index.
+
+## R3: Schedule Fire Recording — New Table
+
+**Decision**: Create a new `schedule_fires` table with FK to `agent_schedules` and optional FK to `agent_runs`.
+
+**Rationale**: No existing table records individual cron fires. The `AgentSchedule` model only has `consecutive_failures`, `last_run_at`, and `next_run_at`. A dedicated table is the cleanest approach — each row is a fire event with timestamp, status (fired, error, skipped), error details, and the resulting run ID.
+
+**Alternatives considered**:
+- JSONB array on AgentSchedule: Unbounded growth, no indexing, awkward retention.
+- Overload AgentRun: Not all fires produce runs (e.g., agent stopped); fires that fail before a run starts need their own record.
+
+## R4: MCP Tool Pattern
+
+**Decision**: Follow the existing `list_executions` / `describe_execution` pattern. New tools: `list_orchestration_runs`, `describe_orchestration_run`, `list_schedule_fires`.
+
+**Rationale**: The MCP create server handler already dispatches tools via a name→method dict. The tool_registry.py defines tool schemas. This pattern is well-established and clients already understand it.
+
+**Alternatives considered**: None — this is the standard pattern.
+
+## R5: Telemetry Webhook Enhancement
+
+**Decision**: Add `orchestration_run` as a new event type in `telemetry_config`. When enabled, `emit_telemetry_event` fires a run-completion payload after the orchestrator records the run. Backward compatible — existing `tool_call` behavior unchanged unless the namespace opts in.
+
+**Rationale**: The telemetry service already supports config-driven event types via `telemetry_config` JSONB on the Namespace model. Adding a new event type requires no schema change — just a new key in the config dict and a new emit call in the orchestrator.
+
+**Alternatives considered**:
+- SSE via telemetry bus: Already exists for real-time streaming, but ephemeral (lost on restart). The webhook provides durable push notification.
+
+## R6: Retention Strategy
+
+**Decision**: Background task prunes `agent_runs` older than 30 days and `schedule_fires` older than 90 days. Configurable via namespace-level settings (future, not MVP).
+
+**Rationale**: 500 runs/day × 30 days = 15,000 rows per agent. With ~10 steps per run, ~150,000 tool_call rows per agent. At ~50 active agents, total is <10M rows — well within PostgreSQL comfort zone. Fires are smaller (~1,000 per agent over 90 days).
+
+**Alternatives considered**:
+- Partition by month: Premature optimization at current scale.
+- No retention: Risk of unbounded growth.
+
+## R7: Outcome Classification
+
+**Decision**: Extend `RUN_STATUSES` from `("running", "completed", "failed", "timeout")` to include `"no_action"` and `"limit_hit"`. The orchestrator already sets status; this adds two new values that map to FR-002's outcome taxonomy.
+
+**Rationale**: The spec requires distinguishing "completed successfully", "completed but chose not to act", "hit a limit", "errored", "cancelled", and "timed out". Mapping: `completed` → completed, `no_action` → no_action_taken, `limit_hit` → limit_hit, `failed` → error, `cancelled` → cancelled (new), `timeout` → timed_out (existing).
+
+**Alternatives considered**:
+- Separate `outcome` column: Would require keeping `status` and `outcome` in sync. Better to extend the existing status enum.
+
+## R8: Limits Tracking
+
+**Decision**: Add `limits_consumed` and `limits_configured` JSONB columns to `agent_runs`. Structure: `{"iterations": N, "ai_tokens": N, "functions_called": N, "execution_seconds": N}`.
+
+**Rationale**: The orchestrator already tracks these values in `OrchestrationResult`. Persisting them as JSONB avoids 8 new columns while still being queryable via PostgreSQL JSON operators. The spec requires showing "consumed vs. configured" for limit_hit diagnosis.
+
+**Alternatives considered**:
+- 8 individual columns (4 consumed + 4 configured): Verbose, inflexible if new limits are added.
+- Only store on limit_hit runs: Loses diagnostic value for runs that completed near limits.

--- a/specs/027-orchestration-observability/spec.md
+++ b/specs/027-orchestration-observability/spec.md
@@ -1,0 +1,132 @@
+# Feature Specification: Orchestration Pipeline Observability
+
+**Feature Branch**: `027-orchestration-observability`  
+**Created**: 2026-04-14  
+**Status**: Draft  
+**Input**: PROBLEM-029 — Orchestration pipeline between "cron fires" and "function executes" is invisible. Agents hallucinate explanations for their own behavior and failures go undetected.
+
+## Clarifications
+
+### Session 2026-04-14
+
+- Q: What level of AI reasoning should be captured in orchestration run steps? → A: Structured decision log — record decision type (called function, skipped function, no action) plus a reason category enum (quality_threshold_not_met, no_matching_data, limit_reached, error, etc.). No free-text AI summaries to avoid PII exposure from ingested tool results.
+- Q: What happens when a cron fires while a previous run is still active? → A: No gating — the system does not prevent concurrent runs. Every fire is recorded and produces a run. Overlapping runs appear in history so the owner can see concurrency and adjust their schedule if needed. The scheduler has no reliable way to check run state without introducing race conditions.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Diagnose Why a Scheduled Agent Didn't Act (Priority: P1)
+
+A namespace owner has an agent running on a cron schedule (e.g., find news and post to social media every 6 hours). The agent stops producing output. The owner needs to determine whether the agent chose not to act, failed silently, hit an orchestration limit, or never fired at all — without contacting the platform operator.
+
+**Why this priority**: This is the exact scenario that triggered PROBLEM-029. Without this, every "why isn't my agent doing X?" question requires platform operator intervention. This is the #1 barrier to client self-service for scheduled automation.
+
+**Independent Test**: Can be fully tested by running a scheduled agent, then querying its orchestration run history to see the trigger, reasoning steps, function calls made, and final outcome. Delivers immediate diagnostic value.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent with a cron schedule that has fired 5 times in the last 24 hours, **When** the owner queries orchestration run history for that agent, **Then** they see all 5 runs with trigger source, start/end time, steps taken, and final outcome.
+2. **Given** an orchestration run where the agent AI decided not to call any functions, **When** the owner views that run, **Then** the outcome is clearly marked as "no action taken" (not indistinguishable from a failure or a non-fire).
+3. **Given** an orchestration run that terminated because it hit `max_iterations`, **When** the owner views that run, **Then** the outcome shows "limit hit" with which limit was reached and current vs. configured values.
+4. **Given** an agent with zero orchestration runs in a time period, **When** the owner checks cron fire history, **Then** they can distinguish "schedule didn't fire" from "schedule fired but produced no recorded run."
+
+---
+
+### User Story 2 - Trace a Function Execution Back to Its Trigger (Priority: P2)
+
+A namespace owner sees a function execution in their activity log and needs to understand what caused it — was it a cron schedule, a chat message, a webhook, or a manual invocation? They need to see the full context: what else happened in the same orchestration run, what the agent was trying to accomplish, and whether it succeeded.
+
+**Why this priority**: Without execution-to-run correlation, function executions are disconnected data points. Owners can see individual calls but not the story they're part of. This is essential for understanding agent behavior patterns and debugging multi-step workflows.
+
+**Independent Test**: Can be tested by triggering an orchestration run that calls multiple functions, then navigating from any single function execution to the parent run and seeing all sibling executions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a function execution that was triggered by a cron-initiated orchestration run, **When** the owner views that execution, **Then** they see a reference to the parent orchestration run.
+2. **Given** an orchestration run that called 3 functions, **When** the owner views the run, **Then** they see all 3 function executions listed with their individual outcomes and execution order.
+3. **Given** a function execution that was triggered by a direct API call (no orchestration), **When** the owner views that execution, **Then** the orchestration run reference is absent (not a fake "direct" run).
+
+---
+
+### User Story 3 - Cron Fire History (Priority: P2)
+
+A namespace owner has a cron schedule configured and wants to verify it's firing on time. Today they can only see a `consecutive_failures` counter and an `enabled` flag. They need actual fire history: when did it fire, what orchestration run did each fire produce, and did any fires fail to start a run.
+
+**Why this priority**: This closes the first gap in the pipeline — without fire history, owners can't distinguish "cron isn't firing" from "cron fires but the run produces nothing useful." Tied with User Story 2 because fire history and execution correlation together provide end-to-end traceability.
+
+**Independent Test**: Can be tested by enabling a cron schedule, waiting for several fires, then querying fire history and verifying timestamps and associated run IDs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cron schedule that has fired 10 times, **When** the owner queries fire history, **Then** they see the last N fires with timestamps and the orchestration run ID each produced.
+2. **Given** a cron fire that failed to start an orchestration run (e.g., agent was stopped), **When** the owner views fire history, **Then** that fire shows a clear error status rather than being silently absent.
+3. **Given** a schedule with `consecutive_failures: 3`, **When** the owner queries fire history, **Then** they can see the specific fires that failed and why.
+
+---
+
+### User Story 4 - Receive Orchestration Run Summaries via Webhook (Priority: P3)
+
+A namespace owner has external tooling (a Discord bot, a Datadog integration, a custom dashboard) and wants to receive a summary whenever an orchestration run completes. Today, telemetry webhooks only fire on individual tool calls — the owner needs run-level events to build holistic monitoring without polling.
+
+**Why this priority**: This extends existing telemetry infrastructure to support the new observability data. Lower priority because the API-based queries (Stories 1-3) provide the core value; webhooks add push-based integration for advanced users.
+
+**Independent Test**: Can be tested by configuring a telemetry webhook with orchestration run events enabled, triggering a run, and verifying the webhook payload includes the run summary.
+
+**Acceptance Scenarios**:
+
+1. **Given** a namespace with a telemetry webhook configured for orchestration run events, **When** an orchestration run completes, **Then** the webhook fires with a payload containing: run ID, agent name, trigger source, outcome, duration, steps taken, and limits consumed.
+2. **Given** a namespace with a telemetry webhook configured only for tool call events (existing behavior), **When** an orchestration run completes, **Then** no additional webhook fires (backward compatible).
+3. **Given** an orchestration run that failed, **When** the webhook fires, **Then** the payload includes the error details sufficient for an external system to create an alert.
+
+---
+
+### Edge Cases
+
+- What happens when an orchestration run is still in progress and the owner queries it? It should show as "running" with steps recorded so far.
+- What happens when cron fire history exceeds retention limits? Oldest entries are pruned; the API indicates whether older history exists.
+- What happens when an orchestration run produces zero function calls and zero AI reasoning (e.g., immediate error)? It still appears in run history with an appropriate error outcome.
+- What happens when the agent is stopped mid-orchestration-run? The run is marked as "cancelled" with the step it was on when stopped.
+- What happens when the telemetry webhook endpoint is unreachable? Same fire-and-forget behavior as existing tool call webhooks — no retry, logged as delivery failure.
+- What happens when a cron fires while a previous run for the same agent is still active? The system does not gate on concurrent runs. Both fires are recorded, both produce runs, and the overlap is visible in run history. The owner can see concurrency and adjust their schedule interval if needed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST record every orchestration run as a queryable entity with a unique identifier, trigger source (cron schedule, chat message, webhook, manual), agent identity, orchestration mode, start time, end time, and final outcome.
+- **FR-002**: System MUST classify orchestration run outcomes as one of: completed, no_action_taken, limit_hit, error, cancelled, timed_out.
+- **FR-003**: System MUST record each step within an orchestration run as a structured decision log: decision type (called function, skipped function, no action) plus a reason category from a fixed enum (e.g., quality_threshold_not_met, no_matching_data, limit_reached, error). No free-text AI summaries are stored, to prevent PII exposure from ingested tool results.
+- **FR-004**: System MUST record which specific limit was hit when an orchestration run terminates due to a limit (iterations, AI tokens, functions called, execution time) and the consumed vs. configured values.
+- **FR-005**: System MUST allow namespace owners to list orchestration runs filtered by agent, trigger type, outcome, and time range.
+- **FR-006**: System MUST allow namespace owners to view the full detail of a single orchestration run including all steps, function executions, and outcome.
+- **FR-007**: System MUST record each cron schedule fire with timestamp, the orchestration run it produced (if any), and error details if the fire failed to start a run.
+- **FR-008**: System MUST allow namespace owners to query fire history for a specific schedule, returning the most recent N fires.
+- **FR-009**: System MUST correlate every function execution produced by an orchestration run back to that run, so owners can navigate from execution to run and from run to executions.
+- **FR-010**: System MUST support an optional telemetry webhook event type for orchestration run completion, including the run summary in the payload.
+- **FR-011**: Enabling orchestration run webhook events MUST NOT affect existing tool call webhook behavior (backward compatible).
+- **FR-012**: System MUST retain orchestration run history and cron fire history for a configurable period, with a reasonable default retention window.
+- **FR-013**: System MUST expose orchestration run data through the same access patterns as existing namespace management (MCP create server tools and REST API).
+
+### Key Entities
+
+- **Orchestration Run**: A single end-to-end execution of the orchestration pipeline for an agent. Triggered by a cron fire, chat message, webhook, or manual invocation. Contains ordered steps, resource consumption, and a final outcome.
+- **Orchestration Step**: A structured decision record within a run. Contains a decision type (called function, skipped function, no action), the target function (if applicable), a reason category from a fixed enum, and the sequence position within the run. No free-text fields — all fields are enumerated or reference existing entities.
+- **Schedule Fire**: A record of a cron schedule triggering. Links to the orchestration run it produced (if successful) or captures why no run was started.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Namespace owners can determine why a scheduled agent didn't act within 60 seconds of investigation, without contacting the platform operator.
+- **SC-002**: 100% of orchestration runs are recorded and queryable — no "dark" runs that execute but leave no trace.
+- **SC-003**: 100% of cron schedule fires are recorded — the gap between `call_count` and `list_executions` results is fully explained by the fire and run history.
+- **SC-004**: Any function execution produced by an orchestration run can be traced back to the run and its trigger source in a single query.
+- **SC-005**: External monitoring tools can receive orchestration run summaries in real-time via webhook without polling, enabling alerting on failures within seconds of occurrence.
+- **SC-006**: Platform operator intervention for "why isn't my agent doing X?" questions is reduced to zero for cases where the answer is observable in run history.
+
+## Assumptions
+
+- The existing `AgentRun` model and telemetry bus provide a foundation to build on rather than replacing from scratch.
+- Orchestration run retention defaults to 30 days, matching typical log retention expectations.
+- Cron fire history retention defaults to 90 days (fires are small records, higher retention is cheap).
+- Steps use structured decision logs (decision type + reason category enum) rather than free-text AI summaries, eliminating PII risk from ingested tool results while preserving diagnostic value.
+- MCP tool exposure follows the same pattern as existing `list_executions` / `describe_execution` tools.

--- a/specs/027-orchestration-observability/tasks.md
+++ b/specs/027-orchestration-observability/tasks.md
@@ -1,0 +1,207 @@
+# Tasks: Orchestration Pipeline Observability
+
+**Input**: Design documents from `/specs/027-orchestration-observability/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/rest-api.md, quickstart.md
+
+**Organization**: Tasks grouped by user story. No test tasks generated (not requested in spec).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+- Exact file paths included in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Database migration covering all schema changes for this feature
+
+- [x] T001 Create Alembic migration adding columns to `agent_runs` (outcome, orchestration_mode, limits_consumed JSONB, limits_configured JSONB, schedule_id FK, functions_called_count), columns to `agent_tool_calls` (decision_type with server_default 'call', reason_category), and new `schedule_fires` table with indexes — in `alembic/versions/YYYYMMDD_add_orchestration_observability.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Models and schemas that all user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T002 Extend `RUN_STATUSES` tuple to include `"no_action"`, `"limit_hit"`, `"cancelled"` and add new columns (outcome, orchestration_mode, limits_consumed, limits_configured, schedule_id FK, functions_called_count) to AgentRun model with relationship to schedule_fires — in `src/mcpworks_api/models/agent.py`
+- [x] T003 [P] Add `decision_type` (String(20), default 'call') and `reason_category` (String(50), nullable) columns to AgentToolCall model. Define `DECISION_TYPES = ("call", "skip", "no_action", "limit_check")` and `REASON_CATEGORIES` tuple with validators — in `src/mcpworks_api/models/agent_tool_call.py`
+- [x] T004 [P] Create ScheduleFire model with schedule_id FK, agent_id FK, fired_at, status, agent_run_id FK, error_detail. Add indexes per data-model.md. Register in `src/mcpworks_api/models/__init__.py` — in `src/mcpworks_api/models/schedule_fire.py`
+- [x] T005 Create Pydantic response schemas: OrchestrationRunSummary (for list), OrchestrationRunDetail (with steps and limits), ScheduleFireSummary, OrchestrationStepDetail. Follow existing schema patterns — in `src/mcpworks_api/schemas/observability.py`
+
+**Checkpoint**: Models and schemas ready — user story implementation can begin
+
+---
+
+## Phase 3: User Story 1 — Diagnose Why a Scheduled Agent Didn't Act (Priority: P1) MVP
+
+**Goal**: Namespace owners can query orchestration run history to see every run's trigger, steps, outcome, and limits consumed — answering "why didn't my agent act?" without operator intervention.
+
+**Independent Test**: Run a scheduled agent through several cron fires, then query `list_orchestration_runs` and `describe_orchestration_run` via MCP tools. Verify runs show trigger source, structured decision steps, outcome classification, and limit consumption.
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] Modify `_record_run()` in orchestrator to persist outcome classification (map OrchestrationResult to no_action/limit_hit/completed/failed/timeout), orchestration_mode, limits_consumed and limits_configured JSONB, functions_called_count, and schedule_id when triggered by cron — in `src/mcpworks_api/tasks/orchestrator.py`
+- [x] T007 [US1] Modify orchestrator loop to emit structured decision steps: for each iteration, create AgentToolCall with decision_type ('call' when invoking function, 'skip' when AI decides against, 'no_action' at end of run with no calls) and reason_category. Update existing tool_call_records construction to include the new fields — in `src/mcpworks_api/tasks/orchestrator.py`
+- [x] T008 [US1] Create ObservabilityService with methods: `list_runs(agent_id, trigger_type, outcome, since, until, limit, offset)` and `get_run(run_id)` returning run with eagerly-loaded tool_calls (steps). Use existing get_db_context pattern — in `src/mcpworks_api/services/observability_service.py`
+- [x] T009 [US1] Register `list_orchestration_runs` and `describe_orchestration_run` tool definitions in tool registry per contracts/rest-api.md schemas — in `src/mcpworks_api/mcp/tool_registry.py`
+- [x] T010 [US1] Implement `_list_orchestration_runs` and `_describe_orchestration_run` handler methods in create_handler, wiring to ObservabilityService. Register in tool dispatch dict — in `src/mcpworks_api/mcp/create_handler.py`
+- [x] T011 [US1] Create REST endpoints `GET /v1/agents/{agent_id}/runs` (list with filters/pagination) and `GET /v1/agents/{agent_id}/runs/{run_id}` (detail with steps). Wire to ObservabilityService — in `src/mcpworks_api/routers/observability.py`
+- [x] T012 [US1] Register observability router in FastAPI app — in `src/mcpworks_api/main.py`
+
+**Checkpoint**: US1 complete — owners can query run history via MCP tools and REST to diagnose agent behavior
+
+---
+
+## Phase 4: User Story 2 — Trace Execution to Trigger (Priority: P2)
+
+**Goal**: Namespace owners can navigate from any function execution to the orchestration run that caused it, and from any run to all its constituent executions.
+
+**Independent Test**: Trigger an orchestration run that calls multiple functions. Use `describe_execution` to verify it includes the parent run reference. Use `describe_orchestration_run` to verify it lists all child executions.
+
+### Implementation for User Story 2
+
+- [x] T013 [US2] Ensure orchestrator sets `agent_run_id` on Execution records when executing functions within an orchestration run. The FK exists (added in 025); verify it's being populated in the sandbox execution path — in `src/mcpworks_api/tasks/orchestrator.py`
+- [x] T014 [US2] Extend `_describe_execution` MCP handler to include `agent_run_id` and basic run summary (trigger_type, outcome) in the response when the execution has a parent run — in `src/mcpworks_api/mcp/create_handler.py`
+- [x] T015 [US2] Extend `get_run()` in ObservabilityService to include associated Execution records (query executions WHERE agent_run_id = run.id, ordered by created_at) — in `src/mcpworks_api/services/observability_service.py`
+- [x] T016 [US2] Update OrchestrationRunDetail schema to include `executions` list with execution_id, function_name, status, duration_ms — in `src/mcpworks_api/schemas/observability.py`
+
+**Checkpoint**: US1 + US2 complete — bidirectional navigation between runs and executions
+
+---
+
+## Phase 5: User Story 3 — Cron Fire History (Priority: P2)
+
+**Goal**: Namespace owners can see when each cron schedule fired, whether each fire produced a run, and why it failed if it didn't.
+
+**Independent Test**: Enable a cron schedule, wait for fires, then query `list_schedule_fires` via MCP. Verify fire timestamps, run IDs, and error details for failed fires.
+
+### Implementation for User Story 3
+
+- [x] T017 [US3] Modify `_execute_scheduled_function` in scheduler to create a ScheduleFire record at the start of each fire (status='started') and update it with agent_run_id on success or error_detail on failure — in `src/mcpworks_api/tasks/scheduler.py`
+- [x] T018 [US3] Add `list_fires(schedule_id, agent_id, status, since, limit, offset)` method to ObservabilityService — in `src/mcpworks_api/services/observability_service.py`
+- [x] T019 [US3] Register `list_schedule_fires` tool definition in tool registry per contracts/rest-api.md schema — in `src/mcpworks_api/mcp/tool_registry.py`
+- [x] T020 [US3] Implement `_list_schedule_fires` handler method in create_handler, wiring to ObservabilityService. Register in tool dispatch dict — in `src/mcpworks_api/mcp/create_handler.py`
+- [x] T021 [US3] Create REST endpoint `GET /v1/schedules/{schedule_id}/fires` (list with filters/pagination). Wire to ObservabilityService — in `src/mcpworks_api/routers/observability.py`
+
+**Checkpoint**: US1 + US2 + US3 complete — full pipeline visibility from cron fire through run to execution
+
+---
+
+## Phase 6: User Story 4 — Orchestration Run Webhook (Priority: P3)
+
+**Goal**: External tooling receives a webhook payload when an orchestration run completes, enabling push-based monitoring without polling.
+
+**Independent Test**: Configure telemetry webhook with `orchestration_run` event type enabled. Trigger a run. Verify webhook fires with run summary payload. Verify existing tool_call webhooks are unaffected.
+
+### Implementation for User Story 4
+
+- [x] T022 [US4] Add `emit_orchestration_run_event()` function to telemetry service. Check `telemetry_config.events` for `"orchestration_run"` before firing. Build payload per contracts/rest-api.md webhook event schema. Use existing `_deliver_webhook` for delivery — in `src/mcpworks_api/services/telemetry.py`
+- [x] T023 [US4] Call `emit_orchestration_run_event()` from orchestrator after `_record_run()` completes, passing run summary data. Fire-and-forget via `asyncio.create_task` — in `src/mcpworks_api/tasks/orchestrator.py`
+- [x] T024 [US4] Update `configure_telemetry_webhook` MCP tool to accept `"orchestration_run"` as a valid event type in the events list. Document in tool description — in `src/mcpworks_api/mcp/create_handler.py` and `src/mcpworks_api/mcp/tool_registry.py`
+
+**Checkpoint**: All 4 user stories complete — full observability pipeline with push notifications
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Retention, cleanup, and validation
+
+- [x] T025 [P] Create background retention task: prune `agent_runs` older than 30 days (cascades to tool_calls) and `schedule_fires` older than 90 days. Schedule daily via existing APScheduler or lifespan task — in `src/mcpworks_api/tasks/retention.py`
+- [x] T026 [P] Register retention task in app lifespan — in `src/mcpworks_api/main.py`
+- [x] T027 Add Prometheus counter `mcpworks_schedule_fires_total` with labels (agent, schedule_id, status) and record in scheduler on each fire — in `src/mcpworks_api/middleware/observability.py` and `src/mcpworks_api/tasks/scheduler.py`
+- [x] T028 Run `ruff format` and `ruff check --fix` across all modified files. Run `pytest tests/unit/ -q` to verify no regressions
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — migration first
+- **Phase 2 (Foundational)**: Depends on Phase 1 — models need migration columns to exist
+- **Phase 3 (US1)**: Depends on Phase 2 — needs models and schemas
+- **Phase 4 (US2)**: Depends on Phase 3 — needs orchestration runs to exist before tracing to them
+- **Phase 5 (US3)**: Depends on Phase 2 only — can run in parallel with US1
+- **Phase 6 (US4)**: Depends on Phase 3 — needs run recording to emit webhook events
+- **Phase 7 (Polish)**: Depends on all user stories
+
+### User Story Dependencies
+
+- **US1 (P1)**: Foundational only — no story dependencies
+- **US2 (P2)**: Depends on US1 (runs must be recorded before executions can link to them)
+- **US3 (P2)**: Foundational only — independent of US1/US2 (can parallelize with US1)
+- **US4 (P3)**: Depends on US1 (runs must be recorded before webhook can fire)
+
+### Within Each User Story
+
+- Orchestrator/scheduler changes before service layer
+- Service layer before MCP tools and REST endpoints
+- MCP tools and REST endpoints can be parallel (different files)
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel (different model files)
+- T009 and T011 can run in parallel within US1 (tool_registry vs router)
+- US1 and US3 can run in parallel after Phase 2 (independent stories)
+- T025 and T026 can run in parallel in Polish phase
+- T019/T020 and T021 can run in parallel within US3 (MCP vs REST)
+
+---
+
+## Parallel Example: User Story 1
+
+```
+# After T007 completes (orchestrator emits steps), launch in parallel:
+T009: Register MCP tool definitions in tool_registry.py
+T011: Create REST endpoints in routers/observability.py
+
+# Then sequentially:
+T010: Implement MCP handlers (needs T009 definitions)
+T012: Register router in main.py (needs T011 router)
+```
+
+## Parallel Example: Phase 2
+
+```
+# After T001 migration, launch in parallel:
+T003: AgentToolCall model extensions in agent_tool_call.py
+T004: ScheduleFire model in schedule_fire.py
+
+# T002 (AgentRun) and T005 (schemas) run sequentially after T003/T004
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Migration
+2. Complete Phase 2: Models + Schemas
+3. Complete Phase 3: US1 (orchestrator → service → MCP tools → REST)
+4. **STOP and VALIDATE**: Query mcpworkssocial agent runs via `list_orchestration_runs`
+5. Deploy if ready — this alone solves the core PROBLEM-029 diagnostic gap
+
+### Incremental Delivery
+
+1. Setup + Foundational → Schema ready
+2. US1 → Run history queryable → Deploy (MVP)
+3. US3 → Fire history queryable → Deploy (can parallel with US1)
+4. US2 → Execution↔Run tracing → Deploy
+5. US4 → Webhook push notifications → Deploy
+6. Polish → Retention + metrics → Deploy
+
+---
+
+## Notes
+
+- All new columns are nullable with defaults — zero-downtime migration
+- `decision_type` defaults to `'call'` — existing AgentToolCall rows need no backfill
+- ScheduleFire is write-heavy (one per cron fire) but read-light (queried on demand)
+- Structured decision logs use enums only — no free-text, no PII risk
+- 28 total tasks across 7 phases

--- a/src/mcpworks_api/api/v1/__init__.py
+++ b/src/mcpworks_api/api/v1/__init__.py
@@ -17,6 +17,7 @@ from mcpworks_api.api.v1.legal import router as legal_router
 from mcpworks_api.api.v1.llm import router as llm_router
 from mcpworks_api.api.v1.namespaces import router as namespaces_router
 from mcpworks_api.api.v1.oauth import router as oauth_router
+from mcpworks_api.api.v1.observability import router as observability_router
 from mcpworks_api.api.v1.procedures import router as procedures_router
 from mcpworks_api.api.v1.quickstart import router as quickstart_router
 from mcpworks_api.api.v1.shares import router as shares_router
@@ -49,6 +50,7 @@ router.include_router(admin_router)  # Admin dashboard
 router.include_router(demo_router)  # Demo booking form
 router.include_router(analytics_router)  # Token savings & MCP analytics
 router.include_router(executions_router)  # Execution debugging
+router.include_router(observability_router)  # Orchestration observability
 router.include_router(compliance_router)  # OWASP compliance reporting
 router.include_router(mcp_router)  # A0: MCP JSON-RPC endpoints
 

--- a/src/mcpworks_api/api/v1/observability.py
+++ b/src/mcpworks_api/api/v1/observability.py
@@ -1,0 +1,163 @@
+"""Orchestration observability endpoints — run history and schedule fire history."""
+
+from __future__ import annotations
+
+import uuid
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from mcpworks_api.core.database import get_db
+from mcpworks_api.dependencies import require_active_status
+from mcpworks_api.models.user import User
+from mcpworks_api.schemas.observability import (
+    ExecutionRef,
+    OrchestrationRunDetail,
+    OrchestrationRunListResponse,
+    OrchestrationRunSummary,
+    OrchestrationStepDetail,
+    ScheduleFireListResponse,
+    ScheduleFireSummary,
+)
+from mcpworks_api.services.observability_service import ObservabilityService
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(tags=["observability"])
+
+
+async def _get_current_user(
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(require_active_status),
+) -> User:
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user
+
+
+@router.get("/agents/{agent_id}/runs", response_model=OrchestrationRunListResponse)
+async def list_orchestration_runs(
+    agent_id: uuid.UUID,
+    trigger_type: str | None = Query(None),
+    outcome: str | None = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    user: User = Depends(_get_current_user),  # noqa: ARG001
+    db: AsyncSession = Depends(get_db),
+) -> OrchestrationRunListResponse:
+    svc = ObservabilityService(db)
+    runs, total = await svc.list_runs(
+        agent_id=agent_id,
+        trigger_type=trigger_type,
+        outcome=outcome,
+        limit=limit,
+        offset=offset,
+    )
+    items = [
+        OrchestrationRunSummary(
+            id=str(r.id),
+            agent_id=str(r.agent_id),
+            trigger_type=r.trigger_type,
+            trigger_detail=r.trigger_detail,
+            orchestration_mode=r.orchestration_mode,
+            schedule_id=str(r.schedule_id) if r.schedule_id else None,
+            outcome=r.outcome,
+            status=r.status,
+            functions_called_count=r.functions_called_count,
+            started_at=r.started_at.isoformat() if r.started_at else None,
+            completed_at=r.completed_at.isoformat() if r.completed_at else None,
+            duration_ms=r.duration_ms,
+            error=r.error,
+        )
+        for r in runs
+    ]
+    return OrchestrationRunListResponse(runs=items, total=total, limit=limit, offset=offset)
+
+
+@router.get("/agents/{agent_id}/runs/{run_id}", response_model=OrchestrationRunDetail)
+async def describe_orchestration_run(
+    agent_id: uuid.UUID,
+    run_id: uuid.UUID,
+    user: User = Depends(_get_current_user),  # noqa: ARG001
+    db: AsyncSession = Depends(get_db),
+) -> OrchestrationRunDetail:
+    svc = ObservabilityService(db)
+    run = await svc.get_run(run_id)
+    if not run or run.agent_id != agent_id:
+        raise HTTPException(status_code=404, detail="Orchestration run not found")
+    execs = await svc.get_run_executions(run_id)
+    exec_refs = [
+        ExecutionRef(
+            execution_id=str(e.id),
+            function_name=e.function_name,
+            status=e.status,
+            duration_ms=e.execution_time_ms,
+        )
+        for e in execs
+    ]
+    steps = [
+        OrchestrationStepDetail(
+            sequence_number=tc.sequence_number,
+            decision_type=tc.decision_type,
+            tool_name=tc.tool_name,
+            reason_category=tc.reason_category,
+            duration_ms=tc.duration_ms,
+            status=tc.status,
+        )
+        for tc in run.tool_calls
+    ]
+    return OrchestrationRunDetail(
+        id=str(run.id),
+        agent_id=str(run.agent_id),
+        trigger_type=run.trigger_type,
+        trigger_detail=run.trigger_detail,
+        orchestration_mode=run.orchestration_mode,
+        schedule_id=str(run.schedule_id) if run.schedule_id else None,
+        outcome=run.outcome,
+        status=run.status,
+        functions_called_count=run.functions_called_count,
+        started_at=run.started_at.isoformat() if run.started_at else None,
+        completed_at=run.completed_at.isoformat() if run.completed_at else None,
+        duration_ms=run.duration_ms,
+        limits_consumed=run.limits_consumed,
+        limits_configured=run.limits_configured,
+        result_summary=run.result_summary,
+        error=run.error,
+        steps=steps,
+        executions=exec_refs,
+    )
+
+
+@router.get("/schedules/{schedule_id}/fires", response_model=ScheduleFireListResponse)
+async def list_schedule_fires(
+    schedule_id: uuid.UUID,
+    status: str | None = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    user: User = Depends(_get_current_user),  # noqa: ARG001
+    db: AsyncSession = Depends(get_db),
+) -> ScheduleFireListResponse:
+    svc = ObservabilityService(db)
+    fires, total = await svc.list_fires(
+        schedule_id=schedule_id,
+        status=status,
+        limit=limit,
+        offset=offset,
+    )
+    items = [
+        ScheduleFireSummary(
+            id=str(f.id),
+            schedule_id=str(f.schedule_id),
+            agent_id=str(f.agent_id),
+            fired_at=f.fired_at.isoformat() if f.fired_at else None,
+            status=f.status,
+            agent_run_id=str(f.agent_run_id) if f.agent_run_id else None,
+            error_detail=f.error_detail,
+        )
+        for f in fires
+    ]
+    return ScheduleFireListResponse(fires=items, total=total, limit=limit, offset=offset)

--- a/src/mcpworks_api/main.py
+++ b/src/mcpworks_api/main.py
@@ -54,6 +54,15 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
             with contextlib.suppress(Exception):
                 await cleanup_analytics_data()
 
+    async def _retention_loop() -> None:
+        from mcpworks_api.tasks.retention import prune_observability_data
+
+        await asyncio.sleep(3600)
+        while True:
+            with contextlib.suppress(Exception):
+                await prune_observability_data()
+            await asyncio.sleep(86400)
+
     async def _telemetry_batch_loop() -> None:
         from mcpworks_api.services.telemetry import flush_telemetry_batches
 
@@ -66,6 +75,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     discord_task = asyncio.create_task(run_discord_gateway())
     cleanup_task = asyncio.create_task(_daily_cleanup_loop())
     telemetry_batch_task = asyncio.create_task(_telemetry_batch_loop())
+    retention_task = asyncio.create_task(_retention_loop())
 
     async with session_manager.run():
         yield
@@ -75,6 +85,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     discord_task.cancel()
     cleanup_task.cancel()
     telemetry_batch_task.cancel()
+    retention_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await scheduler_task
     with contextlib.suppress(asyncio.CancelledError):
@@ -83,6 +94,8 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         await cleanup_task
     with contextlib.suppress(asyncio.CancelledError):
         await telemetry_batch_task
+    with contextlib.suppress(asyncio.CancelledError):
+        await retention_task
 
     await close_db()
     await close_redis()

--- a/src/mcpworks_api/mcp/create_handler.py
+++ b/src/mcpworks_api/mcp/create_handler.py
@@ -176,6 +176,9 @@ class CreateMCPHandler:
         "update_security_scanner": "write",
         "remove_security_scanner": "write",
         "configure_telemetry_webhook": "write",
+        "list_orchestration_runs": "read",
+        "describe_orchestration_run": "read",
+        "list_schedule_fires": "read",
     }
 
     _logger = structlog.get_logger(__name__)
@@ -539,6 +542,9 @@ class CreateMCPHandler:
             "update_security_scanner": self._update_security_scanner,
             "remove_security_scanner": self._remove_security_scanner,
             "configure_telemetry_webhook": self._configure_telemetry_webhook,
+            "list_orchestration_runs": self._list_orchestration_runs,
+            "describe_orchestration_run": self._describe_orchestration_run,
+            "list_schedule_fires": self._list_schedule_fires,
         }
 
         handler = handlers.get(name)
@@ -3404,6 +3410,7 @@ class CreateMCPHandler:
         secret: str | None = None,
         batch_enabled: bool | None = None,
         batch_interval_seconds: int | None = None,
+        events: list[str] | None = None,
         remove: bool = False,
     ) -> MCPToolResult:
         ns = await self._get_current_namespace()
@@ -3436,6 +3443,9 @@ class CreateMCPHandler:
             config["batch_enabled"] = batch_enabled
         if batch_interval_seconds is not None:
             config["batch_interval_seconds"] = max(1, min(60, batch_interval_seconds))
+        if events is not None:
+            valid_events = {"tool_call", "orchestration_run"}
+            config["events"] = [e for e in events if e in valid_events]
         if config:
             ns.telemetry_config = config
 
@@ -3458,4 +3468,127 @@ class CreateMCPHandler:
                     )
                 )
             ]
+        )
+
+    async def _list_orchestration_runs(
+        self, agent: str, trigger_type: str | None = None,
+        outcome: str | None = None, limit: int = 10,
+    ) -> MCPToolResult:
+        from mcpworks_api.services.observability_service import ObservabilityService
+
+        service = AgentService(self.db)
+        agent_obj = await service.get_agent(self.account.id, agent)
+        svc = ObservabilityService(self.db)
+        runs, total = await svc.list_runs(
+            agent_id=agent_obj.id,
+            trigger_type=trigger_type,
+            outcome=outcome,
+            limit=min(limit, 50),
+        )
+        items = []
+        for r in runs:
+            items.append({
+                "id": str(r.id),
+                "trigger_type": r.trigger_type,
+                "trigger_detail": r.trigger_detail,
+                "orchestration_mode": r.orchestration_mode,
+                "outcome": r.outcome,
+                "status": r.status,
+                "functions_called_count": r.functions_called_count,
+                "started_at": r.started_at.isoformat() if r.started_at else None,
+                "completed_at": r.completed_at.isoformat() if r.completed_at else None,
+                "duration_ms": r.duration_ms,
+                "error": r.error,
+            })
+        return MCPToolResult(
+            content=[MCPContent(text=json.dumps({"runs": items, "total": total}))]
+        )
+
+    async def _describe_orchestration_run(self, run_id: str) -> MCPToolResult:
+        import uuid as uuid_mod
+
+        from mcpworks_api.services.observability_service import ObservabilityService
+
+        svc = ObservabilityService(self.db)
+        try:
+            rid = uuid_mod.UUID(run_id)
+        except ValueError:
+            raise ValueError(f"Invalid run ID: {run_id}")
+        run = await svc.get_run(rid)
+        if not run:
+            raise ValueError(f"Orchestration run '{run_id}' not found")
+        steps = []
+        for tc in run.tool_calls:
+            steps.append({
+                "sequence_number": tc.sequence_number,
+                "decision_type": tc.decision_type,
+                "tool_name": tc.tool_name,
+                "reason_category": tc.reason_category,
+                "duration_ms": tc.duration_ms,
+                "status": tc.status,
+            })
+        execs = await svc.get_run_executions(rid)
+        exec_refs = [
+            {
+                "execution_id": str(e.id),
+                "function_name": e.function_name,
+                "status": e.status,
+                "duration_ms": e.execution_time_ms,
+            }
+            for e in execs
+        ]
+        detail = {
+            "id": str(run.id),
+            "agent_id": str(run.agent_id),
+            "trigger_type": run.trigger_type,
+            "trigger_detail": run.trigger_detail,
+            "orchestration_mode": run.orchestration_mode,
+            "outcome": run.outcome,
+            "status": run.status,
+            "functions_called_count": run.functions_called_count,
+            "started_at": run.started_at.isoformat() if run.started_at else None,
+            "completed_at": run.completed_at.isoformat() if run.completed_at else None,
+            "duration_ms": run.duration_ms,
+            "limits_consumed": run.limits_consumed,
+            "limits_configured": run.limits_configured,
+            "result_summary": run.result_summary,
+            "error": run.error,
+            "steps": steps,
+            "executions": exec_refs,
+        }
+        return MCPToolResult(
+            content=[MCPContent(text=json.dumps(detail))]
+        )
+
+    async def _list_schedule_fires(
+        self, agent: str, schedule_id: str | None = None,
+        status: str | None = None, limit: int = 10,
+    ) -> MCPToolResult:
+        import uuid as uuid_mod
+
+        from mcpworks_api.services.observability_service import ObservabilityService
+
+        service = AgentService(self.db)
+        agent_obj = await service.get_agent(self.account.id, agent)
+        svc = ObservabilityService(self.db)
+        sched_uuid = uuid_mod.UUID(schedule_id) if schedule_id else None
+        fires, total = await svc.list_fires(
+            schedule_id=sched_uuid,
+            agent_id=agent_obj.id,
+            status=status,
+            limit=min(limit, 50),
+        )
+        items = []
+        for f in fires:
+            items.append({
+                "id": str(f.id),
+                "schedule_id": str(f.schedule_id),
+                "agent_id": str(f.agent_id),
+                "fired_at": f.fired_at.isoformat() if f.fired_at else None,
+                "status": f.status,
+                "agent_run_id": str(f.agent_run_id) if f.agent_run_id else None,
+                "error_detail": f.error_detail,
+            })
+        return MCPToolResult(
+            content=[MCPContent(text=json.dumps({"fires": items, "total": total}))]
         )

--- a/src/mcpworks_api/mcp/create_handler.py
+++ b/src/mcpworks_api/mcp/create_handler.py
@@ -3471,8 +3471,11 @@ class CreateMCPHandler:
         )
 
     async def _list_orchestration_runs(
-        self, agent: str, trigger_type: str | None = None,
-        outcome: str | None = None, limit: int = 10,
+        self,
+        agent: str,
+        trigger_type: str | None = None,
+        outcome: str | None = None,
+        limit: int = 10,
     ) -> MCPToolResult:
         from mcpworks_api.services.observability_service import ObservabilityService
 
@@ -3487,22 +3490,22 @@ class CreateMCPHandler:
         )
         items = []
         for r in runs:
-            items.append({
-                "id": str(r.id),
-                "trigger_type": r.trigger_type,
-                "trigger_detail": r.trigger_detail,
-                "orchestration_mode": r.orchestration_mode,
-                "outcome": r.outcome,
-                "status": r.status,
-                "functions_called_count": r.functions_called_count,
-                "started_at": r.started_at.isoformat() if r.started_at else None,
-                "completed_at": r.completed_at.isoformat() if r.completed_at else None,
-                "duration_ms": r.duration_ms,
-                "error": r.error,
-            })
-        return MCPToolResult(
-            content=[MCPContent(text=json.dumps({"runs": items, "total": total}))]
-        )
+            items.append(
+                {
+                    "id": str(r.id),
+                    "trigger_type": r.trigger_type,
+                    "trigger_detail": r.trigger_detail,
+                    "orchestration_mode": r.orchestration_mode,
+                    "outcome": r.outcome,
+                    "status": r.status,
+                    "functions_called_count": r.functions_called_count,
+                    "started_at": r.started_at.isoformat() if r.started_at else None,
+                    "completed_at": r.completed_at.isoformat() if r.completed_at else None,
+                    "duration_ms": r.duration_ms,
+                    "error": r.error,
+                }
+            )
+        return MCPToolResult(content=[MCPContent(text=json.dumps({"runs": items, "total": total}))])
 
     async def _describe_orchestration_run(self, run_id: str) -> MCPToolResult:
         import uuid as uuid_mod
@@ -3519,14 +3522,16 @@ class CreateMCPHandler:
             raise ValueError(f"Orchestration run '{run_id}' not found")
         steps = []
         for tc in run.tool_calls:
-            steps.append({
-                "sequence_number": tc.sequence_number,
-                "decision_type": tc.decision_type,
-                "tool_name": tc.tool_name,
-                "reason_category": tc.reason_category,
-                "duration_ms": tc.duration_ms,
-                "status": tc.status,
-            })
+            steps.append(
+                {
+                    "sequence_number": tc.sequence_number,
+                    "decision_type": tc.decision_type,
+                    "tool_name": tc.tool_name,
+                    "reason_category": tc.reason_category,
+                    "duration_ms": tc.duration_ms,
+                    "status": tc.status,
+                }
+            )
         execs = await svc.get_run_executions(rid)
         exec_refs = [
             {
@@ -3556,13 +3561,14 @@ class CreateMCPHandler:
             "steps": steps,
             "executions": exec_refs,
         }
-        return MCPToolResult(
-            content=[MCPContent(text=json.dumps(detail))]
-        )
+        return MCPToolResult(content=[MCPContent(text=json.dumps(detail))])
 
     async def _list_schedule_fires(
-        self, agent: str, schedule_id: str | None = None,
-        status: str | None = None, limit: int = 10,
+        self,
+        agent: str,
+        schedule_id: str | None = None,
+        status: str | None = None,
+        limit: int = 10,
     ) -> MCPToolResult:
         import uuid as uuid_mod
 
@@ -3580,15 +3586,17 @@ class CreateMCPHandler:
         )
         items = []
         for f in fires:
-            items.append({
-                "id": str(f.id),
-                "schedule_id": str(f.schedule_id),
-                "agent_id": str(f.agent_id),
-                "fired_at": f.fired_at.isoformat() if f.fired_at else None,
-                "status": f.status,
-                "agent_run_id": str(f.agent_run_id) if f.agent_run_id else None,
-                "error_detail": f.error_detail,
-            })
+            items.append(
+                {
+                    "id": str(f.id),
+                    "schedule_id": str(f.schedule_id),
+                    "agent_id": str(f.agent_id),
+                    "fired_at": f.fired_at.isoformat() if f.fired_at else None,
+                    "status": f.status,
+                    "agent_run_id": str(f.agent_run_id) if f.agent_run_id else None,
+                    "error_detail": f.error_detail,
+                }
+            )
         return MCPToolResult(
             content=[MCPContent(text=json.dumps({"fires": items, "total": total}))]
         )

--- a/src/mcpworks_api/mcp/tool_registry.py
+++ b/src/mcpworks_api/mcp/tool_registry.py
@@ -2469,8 +2469,9 @@ ANALYTICS_TOOLS: dict[str, ToolDef] = {
         name="configure_telemetry_webhook",
         brief="Set, update, or remove a telemetry webhook for this namespace.",
         description=(
-            "Configure a webhook URL that receives execution metadata on every tool call. "
+            "Configure a webhook URL that receives execution metadata. "
             "Supports HMAC-SHA256 signing and optional event batching. "
+            "Set events=['tool_call','orchestration_run'] to receive run completion summaries. "
             "Set remove=true to disable the webhook."
         ),
         input_schema={
@@ -2492,11 +2493,101 @@ ANALYTICS_TOOLS: dict[str, ToolDef] = {
                     "type": "integer",
                     "description": "Flush interval for batching in seconds (1-60, default: 10).",
                 },
+                "events": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": ["tool_call", "orchestration_run"]},
+                    "description": "Event types to receive (default: ['tool_call']).",
+                },
                 "remove": {
                     "type": "boolean",
                     "description": "Set true to remove the webhook entirely.",
                 },
             },
+        },
+    ),
+    "list_orchestration_runs": ToolDef(
+        name="list_orchestration_runs",
+        brief="List orchestration runs for an agent.",
+        description=(
+            "List orchestration runs for an agent with optional filters. Returns run ID, "
+            "trigger source, outcome, duration, and function call count. "
+            "Example: list_orchestration_runs(agent='social-bot', outcome='no_action')."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "type": "string",
+                    "description": "Agent name.",
+                },
+                "trigger_type": {
+                    "type": "string",
+                    "enum": ["cron", "webhook", "manual", "ai", "heartbeat"],
+                    "description": "Filter by trigger type.",
+                },
+                "outcome": {
+                    "type": "string",
+                    "enum": ["completed", "no_action", "limit_hit", "error", "timeout", "cancelled"],
+                    "description": "Filter by run outcome.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (1-50, default: 10).",
+                },
+            },
+            "required": ["agent"],
+        },
+    ),
+    "describe_orchestration_run": ToolDef(
+        name="describe_orchestration_run",
+        brief="Get full detail of an orchestration run.",
+        description=(
+            "Get full detail of an orchestration run including decision steps, "
+            "limits consumed vs configured, and function executions. "
+            "Use list_orchestration_runs to find run IDs. "
+            "Example: describe_orchestration_run(run_id='abc-123-def')."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "run_id": {
+                    "type": "string",
+                    "description": "Orchestration run UUID.",
+                },
+            },
+            "required": ["run_id"],
+        },
+    ),
+    "list_schedule_fires": ToolDef(
+        name="list_schedule_fires",
+        brief="List fire history for a cron schedule.",
+        description=(
+            "List fire history for a cron schedule showing when each fire occurred, "
+            "whether it produced a run, and error details for failed fires. "
+            "Example: list_schedule_fires(agent='social-bot', schedule_id='abc-123')."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "type": "string",
+                    "description": "Agent name.",
+                },
+                "schedule_id": {
+                    "type": "string",
+                    "description": "Schedule UUID (optional if agent provided).",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["started", "error", "skipped"],
+                    "description": "Filter by fire status.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (1-50, default: 10).",
+                },
+            },
+            "required": ["agent"],
         },
     ),
 }

--- a/src/mcpworks_api/mcp/tool_registry.py
+++ b/src/mcpworks_api/mcp/tool_registry.py
@@ -2527,7 +2527,14 @@ ANALYTICS_TOOLS: dict[str, ToolDef] = {
                 },
                 "outcome": {
                     "type": "string",
-                    "enum": ["completed", "no_action", "limit_hit", "error", "timeout", "cancelled"],
+                    "enum": [
+                        "completed",
+                        "no_action",
+                        "limit_hit",
+                        "error",
+                        "timeout",
+                        "cancelled",
+                    ],
                     "description": "Filter by run outcome.",
                 },
                 "limit": {

--- a/src/mcpworks_api/middleware/observability.py
+++ b/src/mcpworks_api/middleware/observability.py
@@ -129,6 +129,15 @@ webhook_delivery_latency_seconds = Histogram(
 
 
 # ---------------------------------------------------------------------------
+# Schedule fires
+# ---------------------------------------------------------------------------
+schedule_fires_total = Counter(
+    "mcpworks_schedule_fires_total",
+    "Cron schedule fire events",
+    ["namespace", "status"],
+)
+
+# ---------------------------------------------------------------------------
 # OAuth
 # ---------------------------------------------------------------------------
 oauth_token_refreshes_total = Counter(
@@ -253,3 +262,7 @@ def record_oauth_device_flow(namespace: str, server: str, status: str) -> None:
 
 def record_oauth_auth_required(namespace: str, server: str, flow: str) -> None:
     oauth_auth_required_total.labels(namespace=namespace, server=server, flow=flow).inc()
+
+
+def record_schedule_fire(namespace: str, status: str) -> None:
+    schedule_fires_total.labels(namespace=namespace, status=status).inc()

--- a/src/mcpworks_api/models/__init__.py
+++ b/src/mcpworks_api/models/__init__.py
@@ -28,6 +28,7 @@ from mcpworks_api.models.namespace_service import NamespaceService
 from mcpworks_api.models.namespace_share import NamespaceShare, ShareStatus
 from mcpworks_api.models.oauth_account import OAuthAccount
 from mcpworks_api.models.procedure import Procedure, ProcedureExecution, ProcedureVersion
+from mcpworks_api.models.schedule_fire import ScheduleFire
 from mcpworks_api.models.security_event import ALLOWED_SEVERITIES, SecurityEvent
 from mcpworks_api.models.service import Service, ServiceStatus
 from mcpworks_api.models.subscription import (
@@ -105,6 +106,8 @@ __all__ = [
     "Procedure",
     "ProcedureVersion",
     "ProcedureExecution",
+    # ScheduleFire (Orchestration Observability)
+    "ScheduleFire",
     # Webhook (A0)
     "Webhook",
 ]

--- a/src/mcpworks_api/models/agent.py
+++ b/src/mcpworks_api/models/agent.py
@@ -28,7 +28,8 @@ AGENT_STATUSES = ("creating", "running", "stopped", "error", "destroying", "degr
 REPLICA_STATUSES = ("creating", "running", "stopped", "error")
 SCHEDULE_MODES = ("single", "cluster")
 JOB_STATUSES = ("pending", "claimed", "running", "complete", "failed")
-RUN_STATUSES = ("running", "completed", "failed", "timeout")
+RUN_STATUSES = ("running", "completed", "failed", "timeout", "no_action", "limit_hit", "cancelled")
+RUN_OUTCOMES = ("completed", "no_action", "limit_hit", "error", "cancelled", "timeout")
 TRIGGER_TYPES = ("cron", "webhook", "manual", "ai", "heartbeat")
 CHANNEL_TYPES = ("discord", "slack", "whatsapp", "email")
 ORCHESTRATION_MODES = ("direct", "reason_first", "run_then_reason", "procedure")
@@ -209,6 +210,16 @@ class AgentRun(Base, UUIDMixin):
     duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     result_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    outcome: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    orchestration_mode: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    limits_consumed: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    limits_configured: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    schedule_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agent_schedules.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    functions_called_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default="now()"
     )
@@ -221,10 +232,17 @@ class AgentRun(Base, UUIDMixin):
         order_by="AgentToolCall.sequence_number",
         lazy="selectin",
     )
+    schedule_fires: Mapped[list["ScheduleFire"]] = relationship(  # noqa: F821
+        "ScheduleFire",
+        back_populates="agent_run",
+        lazy="noload",
+    )
 
     __table_args__ = (
         Index("ix_agent_runs_agent_created", "agent_id", "created_at"),
         Index("ix_agent_runs_created", "created_at"),
+        Index("ix_agent_runs_outcome", "outcome"),
+        Index("ix_agent_runs_schedule", "schedule_id"),
     )
 
     @validates("trigger_type")
@@ -237,6 +255,12 @@ class AgentRun(Base, UUIDMixin):
     def validate_status(self, key: str, value: str) -> str:
         if value not in RUN_STATUSES:
             raise ValueError(f"Invalid run status: {value}")
+        return value
+
+    @validates("outcome")
+    def validate_outcome(self, key: str, value: str | None) -> str | None:
+        if value is not None and value not in RUN_OUTCOMES:
+            raise ValueError(f"Invalid run outcome: {value}")
         return value
 
 

--- a/src/mcpworks_api/models/agent_tool_call.py
+++ b/src/mcpworks_api/models/agent_tool_call.py
@@ -5,12 +5,24 @@ from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 
 from mcpworks_api.models.base import Base, UUIDMixin
 
 TOOL_CALL_SOURCES = ("namespace", "mcp", "platform")
 TOOL_CALL_STATUSES = ("success", "error")
+DECISION_TYPES = ("call", "skip", "no_action", "limit_check")
+REASON_CATEGORIES = (
+    "success",
+    "error",
+    "quality_threshold_not_met",
+    "no_matching_data",
+    "limit_reached",
+    "rate_limited",
+    "access_denied",
+    "timeout",
+    "not_applicable",
+)
 
 MAX_TOOL_INPUT_BYTES = 2048
 MAX_RESULT_PREVIEW_CHARS = 500
@@ -32,6 +44,10 @@ class AgentToolCall(Base, UUIDMixin):
     duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     source: Mapped[str] = mapped_column(String(20), nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False)
+    decision_type: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="call", default="call"
+    )
+    reason_category: Mapped[str | None] = mapped_column(String(50), nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default="now()"
@@ -40,6 +56,18 @@ class AgentToolCall(Base, UUIDMixin):
     agent_run: Mapped["AgentRun"] = relationship(  # noqa: F821
         "AgentRun", back_populates="tool_calls"
     )
+
+    @validates("decision_type")
+    def validate_decision_type(self, key: str, value: str) -> str:
+        if value not in DECISION_TYPES:
+            raise ValueError(f"Invalid decision type: {value}")
+        return value
+
+    @validates("reason_category")
+    def validate_reason_category(self, key: str, value: str | None) -> str | None:
+        if value is not None and value not in REASON_CATEGORIES:
+            raise ValueError(f"Invalid reason category: {value}")
+        return value
 
     __table_args__ = (
         Index("ix_agent_tool_calls_run_seq", "agent_run_id", "sequence_number"),

--- a/src/mcpworks_api/models/schedule_fire.py
+++ b/src/mcpworks_api/models/schedule_fire.py
@@ -1,0 +1,57 @@
+"""Schedule fire audit trail — records each cron schedule fire event."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
+
+from mcpworks_api.models.base import Base, UUIDMixin
+
+FIRE_STATUSES = ("started", "error", "skipped")
+
+
+class ScheduleFire(Base, UUIDMixin):
+    __tablename__ = "schedule_fires"
+
+    schedule_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agent_schedules.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    fired_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default="now()"
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    agent_run_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agent_runs.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    error_detail: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default="now()"
+    )
+
+    schedule: Mapped["AgentSchedule"] = relationship("AgentSchedule")  # noqa: F821
+    agent_run: Mapped["AgentRun | None"] = relationship(  # noqa: F821
+        "AgentRun", back_populates="schedule_fires"
+    )
+
+    __table_args__ = (
+        Index("ix_schedule_fires_schedule_fired", "schedule_id", "fired_at"),
+        Index("ix_schedule_fires_agent_fired", "agent_id", "fired_at"),
+        Index("ix_schedule_fires_created", "created_at"),
+    )
+
+    @validates("status")
+    def validate_status(self, key: str, value: str) -> str:
+        if value not in FIRE_STATUSES:
+            raise ValueError(f"Invalid fire status: {value}")
+        return value

--- a/src/mcpworks_api/schemas/observability.py
+++ b/src/mcpworks_api/schemas/observability.py
@@ -1,0 +1,76 @@
+"""Pydantic schemas for orchestration observability endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class OrchestrationStepDetail(BaseModel):
+    sequence_number: int
+    decision_type: str
+    tool_name: str | None = None
+    reason_category: str | None = None
+    duration_ms: int | None = None
+    status: str | None = None
+
+
+class ExecutionRef(BaseModel):
+    execution_id: str
+    function_name: str | None = None
+    status: str | None = None
+    duration_ms: int | None = None
+
+
+class LimitsSnapshot(BaseModel):
+    iterations: int | None = None
+    ai_tokens: int | None = None
+    functions_called: int | None = None
+    execution_seconds: float | None = None
+
+
+class OrchestrationRunSummary(BaseModel):
+    id: str
+    agent_id: str
+    trigger_type: str
+    trigger_detail: str | None = None
+    orchestration_mode: str | None = None
+    schedule_id: str | None = None
+    outcome: str | None = None
+    status: str
+    functions_called_count: int | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+    duration_ms: int | None = None
+    error: str | None = None
+
+
+class OrchestrationRunDetail(OrchestrationRunSummary):
+    limits_consumed: LimitsSnapshot | None = None
+    limits_configured: LimitsSnapshot | None = None
+    result_summary: str | None = None
+    steps: list[OrchestrationStepDetail] = Field(default_factory=list)
+    executions: list[ExecutionRef] = Field(default_factory=list)
+
+
+class OrchestrationRunListResponse(BaseModel):
+    runs: list[OrchestrationRunSummary]
+    total: int
+    limit: int = Field(default=20)
+    offset: int = Field(default=0)
+
+
+class ScheduleFireSummary(BaseModel):
+    id: str
+    schedule_id: str
+    agent_id: str
+    fired_at: str
+    status: str
+    agent_run_id: str | None = None
+    error_detail: str | None = None
+
+
+class ScheduleFireListResponse(BaseModel):
+    fires: list[ScheduleFireSummary]
+    total: int
+    limit: int = Field(default=20)
+    offset: int = Field(default=0)

--- a/src/mcpworks_api/services/execution.py
+++ b/src/mcpworks_api/services/execution.py
@@ -98,6 +98,7 @@ def _to_detail(e: Execution) -> dict[str, Any]:
             "stdout": meta.get("stdout"),
             "stderr": meta.get("stderr"),
             "created_at": e.created_at.isoformat() if e.created_at else None,
+            "agent_run_id": str(e.agent_run_id) if e.agent_run_id else None,
         }
     )
     return detail

--- a/src/mcpworks_api/services/observability_service.py
+++ b/src/mcpworks_api/services/observability_service.py
@@ -53,18 +53,14 @@ class ObservabilityService:
 
     async def get_run(self, run_id: uuid.UUID) -> AgentRun | None:
         stmt = (
-            select(AgentRun)
-            .options(selectinload(AgentRun.tool_calls))
-            .where(AgentRun.id == run_id)
+            select(AgentRun).options(selectinload(AgentRun.tool_calls)).where(AgentRun.id == run_id)
         )
         result = await self._db.execute(stmt)
         return result.scalar_one_or_none()
 
     async def get_run_executions(self, run_id: uuid.UUID) -> list[Execution]:
         stmt = (
-            select(Execution)
-            .where(Execution.agent_run_id == run_id)
-            .order_by(Execution.created_at)
+            select(Execution).where(Execution.agent_run_id == run_id).order_by(Execution.created_at)
         )
         result = await self._db.execute(stmt)
         return list(result.scalars().all())

--- a/src/mcpworks_api/services/observability_service.py
+++ b/src/mcpworks_api/services/observability_service.py
@@ -1,0 +1,102 @@
+"""Service for querying orchestration run history and schedule fire history."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from mcpworks_api.models.agent import AgentRun
+from mcpworks_api.models.execution import Execution
+from mcpworks_api.models.schedule_fire import ScheduleFire
+
+
+class ObservabilityService:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def list_runs(
+        self,
+        agent_id: uuid.UUID,
+        trigger_type: str | None = None,
+        outcome: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[AgentRun], int]:
+        filters = [AgentRun.agent_id == agent_id]
+        if trigger_type:
+            filters.append(AgentRun.trigger_type == trigger_type)
+        if outcome:
+            filters.append(AgentRun.outcome == outcome)
+        if since:
+            filters.append(AgentRun.created_at >= since)
+        if until:
+            filters.append(AgentRun.created_at <= until)
+
+        count_stmt = select(func.count()).select_from(AgentRun).where(*filters)
+        total = (await self._db.execute(count_stmt)).scalar_one()
+
+        stmt = (
+            select(AgentRun)
+            .where(*filters)
+            .order_by(AgentRun.created_at.desc())
+            .limit(min(limit, 100))
+            .offset(offset)
+        )
+        result = await self._db.execute(stmt)
+        return list(result.scalars().all()), total
+
+    async def get_run(self, run_id: uuid.UUID) -> AgentRun | None:
+        stmt = (
+            select(AgentRun)
+            .options(selectinload(AgentRun.tool_calls))
+            .where(AgentRun.id == run_id)
+        )
+        result = await self._db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_run_executions(self, run_id: uuid.UUID) -> list[Execution]:
+        stmt = (
+            select(Execution)
+            .where(Execution.agent_run_id == run_id)
+            .order_by(Execution.created_at)
+        )
+        result = await self._db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_fires(
+        self,
+        schedule_id: uuid.UUID | None = None,
+        agent_id: uuid.UUID | None = None,
+        status: str | None = None,
+        since: datetime | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[ScheduleFire], int]:
+        filters = []
+        if schedule_id:
+            filters.append(ScheduleFire.schedule_id == schedule_id)
+        if agent_id:
+            filters.append(ScheduleFire.agent_id == agent_id)
+        if status:
+            filters.append(ScheduleFire.status == status)
+        if since:
+            filters.append(ScheduleFire.fired_at >= since)
+
+        count_stmt = select(func.count()).select_from(ScheduleFire).where(*filters)
+        total = (await self._db.execute(count_stmt)).scalar_one()
+
+        stmt = (
+            select(ScheduleFire)
+            .where(*filters)
+            .order_by(ScheduleFire.fired_at.desc())
+            .limit(min(limit, 100))
+            .offset(offset)
+        )
+        result = await self._db.execute(stmt)
+        return list(result.scalars().all()), total

--- a/src/mcpworks_api/services/telemetry.py
+++ b/src/mcpworks_api/services/telemetry.py
@@ -347,9 +347,7 @@ async def emit_orchestration_run_event(
             payload_bytes = json.dumps(payload).encode()
 
             asyncio.create_task(
-                _deliver_webhook(
-                    row.telemetry_webhook_url, payload_bytes, secret, namespace_name
-                )
+                _deliver_webhook(row.telemetry_webhook_url, payload_bytes, secret, namespace_name)
             )
     except Exception:
         logger.debug("orchestration_run_telemetry_failed", namespace=namespace_name, exc_info=True)

--- a/src/mcpworks_api/services/telemetry.py
+++ b/src/mcpworks_api/services/telemetry.py
@@ -277,3 +277,79 @@ async def flush_telemetry_batches() -> None:
 
     except Exception:
         logger.debug("telemetry_batch_flush_failed", exc_info=True)
+
+
+async def emit_orchestration_run_event(
+    namespace_id,
+    namespace_name: str,
+    agent_name: str,
+    run_id: str,
+    trigger_type: str,
+    orchestration_mode: str | None,
+    outcome: str | None,
+    duration_ms: int | None,
+    functions_called_count: int,
+    limits_consumed: dict | None,
+    limits_configured: dict | None,
+    error: str | None = None,
+) -> None:
+    from mcpworks_api.core.database import get_db_context
+    from mcpworks_api.core.encryption import decrypt_value
+    from mcpworks_api.models.namespace import Namespace
+
+    try:
+        async with get_db_context() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(
+                select(
+                    Namespace.telemetry_webhook_url,
+                    Namespace.telemetry_webhook_secret_encrypted,
+                    Namespace.telemetry_webhook_secret_dek,
+                    Namespace.telemetry_config,
+                ).where(Namespace.id == namespace_id)
+            )
+            row = result.first()
+
+            if not row or not row.telemetry_webhook_url:
+                return
+
+            config = row.telemetry_config or {}
+            events = config.get("events", ["tool_call"])
+            if "orchestration_run" not in events:
+                return
+
+            secret = None
+            if row.telemetry_webhook_secret_encrypted and row.telemetry_webhook_secret_dek:
+                try:
+                    secret = decrypt_value(
+                        row.telemetry_webhook_secret_encrypted,
+                        row.telemetry_webhook_secret_dek,
+                    )
+                except Exception:
+                    logger.warning("telemetry_secret_decrypt_failed", namespace=namespace_name)
+
+            payload = {
+                "event_type": "orchestration_run",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "namespace": namespace_name,
+                "agent": agent_name,
+                "run_id": run_id,
+                "trigger_type": trigger_type,
+                "orchestration_mode": orchestration_mode,
+                "outcome": outcome,
+                "duration_ms": duration_ms,
+                "functions_called_count": functions_called_count,
+                "limits_consumed": limits_consumed,
+                "limits_configured": limits_configured,
+                "error": error,
+            }
+            payload_bytes = json.dumps(payload).encode()
+
+            asyncio.create_task(
+                _deliver_webhook(
+                    row.telemetry_webhook_url, payload_bytes, secret, namespace_name
+                )
+            )
+    except Exception:
+        logger.debug("orchestration_run_telemetry_failed", namespace=namespace_name, exc_info=True)

--- a/src/mcpworks_api/tasks/orchestrator.py
+++ b/src/mcpworks_api/tasks/orchestrator.py
@@ -321,8 +321,12 @@ async def run_orchestration(
                     total_tokens=total_tokens,
                 )
                 await _post_orchestration(
-                    agent, trigger_type, result, tool_call_records=tool_call_records,
-                    schedule_id=schedule_id, orchestration_mode=orchestration_mode,
+                    agent,
+                    trigger_type,
+                    result,
+                    tool_call_records=tool_call_records,
+                    schedule_id=schedule_id,
+                    orchestration_mode=orchestration_mode,
                     run_id=run_id,
                 )
                 return result
@@ -548,8 +552,12 @@ async def run_orchestration(
             limits_configured=limits,
         )
         await _record_run(
-            agent, trigger_type, result, tool_call_records=tool_call_records,
-            schedule_id=schedule_id, orchestration_mode=orchestration_mode,
+            agent,
+            trigger_type,
+            result,
+            tool_call_records=tool_call_records,
+            schedule_id=schedule_id,
+            orchestration_mode=orchestration_mode,
             run_id=run_id,
         )
         return result
@@ -568,8 +576,12 @@ async def run_orchestration(
             limits_configured=limits,
         )
         await _record_run(
-            agent, trigger_type, result, tool_call_records=tool_call_records,
-            schedule_id=schedule_id, orchestration_mode=orchestration_mode,
+            agent,
+            trigger_type,
+            result,
+            tool_call_records=tool_call_records,
+            schedule_id=schedule_id,
+            orchestration_mode=orchestration_mode,
             run_id=run_id,
         )
         return result
@@ -965,8 +977,12 @@ async def _post_orchestration(
             logger.exception("auto_channel_send_failed", agent_name=agent.name)
 
     await _record_run(
-        agent, trigger_type, result, tool_call_records=tool_call_records,
-        schedule_id=schedule_id, orchestration_mode=orchestration_mode,
+        agent,
+        trigger_type,
+        result,
+        tool_call_records=tool_call_records,
+        schedule_id=schedule_id,
+        orchestration_mode=orchestration_mode,
         run_id=run_id,
     )
 

--- a/src/mcpworks_api/tasks/orchestrator.py
+++ b/src/mcpworks_api/tasks/orchestrator.py
@@ -101,6 +101,10 @@ class OrchestrationResult:
     duration_ms: int = 0
     error: str | None = None
     context_tokens: int = 0
+    outcome: str | None = None
+    limit_name: str | None = None
+    limits_consumed: dict | None = None
+    limits_configured: dict | None = None
 
 
 async def run_orchestration(
@@ -110,6 +114,8 @@ async def run_orchestration(
     trigger_data: dict,  # noqa: ARG001  — reserved for future use (logging, state)
     tier: str,
     account: Account,
+    schedule_id: str | None = None,
+    orchestration_mode: str | None = None,
 ) -> OrchestrationResult:
     """Execute the AI orchestration loop for an agent."""
     start_time = time.monotonic()
@@ -253,6 +259,7 @@ async def run_orchestration(
                     total_tokens,
                     start_time,
                     context_tokens,
+                    limits=limits,
                 )
             if _elapsed_seconds(start_time) >= limits["max_execution_seconds"]:
                 return _limit_result(
@@ -262,6 +269,7 @@ async def run_orchestration(
                     total_tokens,
                     start_time,
                     context_tokens,
+                    limits=limits,
                 )
 
             response = await chat_with_tools(
@@ -286,6 +294,13 @@ async def run_orchestration(
 
             if stop_reason != "tool_use":
                 final_text = _extract_text(content_blocks)
+                _consumed = {
+                    "iterations": iterations,
+                    "ai_tokens": total_tokens,
+                    "functions_called": len(functions_called),
+                    "execution_seconds": round(_elapsed_seconds(start_time), 1),
+                }
+                outcome = "completed" if functions_called else "no_action"
                 result = OrchestrationResult(
                     success=True,
                     final_text=final_text,
@@ -294,6 +309,9 @@ async def run_orchestration(
                     total_tokens=total_tokens,
                     duration_ms=_elapsed_ms(start_time),
                     context_tokens=context_tokens,
+                    outcome=outcome,
+                    limits_consumed=_consumed,
+                    limits_configured=limits,
                 )
                 _emit(
                     "completion",
@@ -303,7 +321,9 @@ async def run_orchestration(
                     total_tokens=total_tokens,
                 )
                 await _post_orchestration(
-                    agent, trigger_type, result, tool_call_records=tool_call_records
+                    agent, trigger_type, result, tool_call_records=tool_call_records,
+                    schedule_id=schedule_id, orchestration_mode=orchestration_mode,
+                    run_id=run_id,
                 )
                 return result
 
@@ -469,6 +489,8 @@ async def run_orchestration(
                         "duration_ms": tc_duration_ms,
                         "source": source,
                         "status": tc_status,
+                        "decision_type": "call",
+                        "reason_category": "error" if is_error else "success",
                         "error_message": (
                             _scrub_error_message(result_str[:MAX_ERROR_CHARS]) if is_error else None
                         ),
@@ -493,6 +515,7 @@ async def run_orchestration(
                         total_tokens,
                         start_time,
                         context_tokens,
+                        limits=limits,
                     )
 
         return _limit_result(
@@ -502,6 +525,7 @@ async def run_orchestration(
             total_tokens,
             start_time,
             context_tokens,
+            limits=limits,
         )
 
     except AIClientError as e:
@@ -520,8 +544,14 @@ async def run_orchestration(
             total_tokens=total_tokens,
             duration_ms=_elapsed_ms(start_time),
             error=str(e)[:500],
+            outcome="error",
+            limits_configured=limits,
         )
-        await _record_run(agent, trigger_type, result, tool_call_records=tool_call_records)
+        await _record_run(
+            agent, trigger_type, result, tool_call_records=tool_call_records,
+            schedule_id=schedule_id, orchestration_mode=orchestration_mode,
+            run_id=run_id,
+        )
         return result
     except Exception as e:
         _emit("error", message=str(e)[:300], phase="orchestration")
@@ -534,8 +564,14 @@ async def run_orchestration(
             total_tokens=total_tokens,
             duration_ms=_elapsed_ms(start_time),
             error=str(e)[:500],
+            outcome="error",
+            limits_configured=limits,
         )
-        await _record_run(agent, trigger_type, result, tool_call_records=tool_call_records)
+        await _record_run(
+            agent, trigger_type, result, tool_call_records=tool_call_records,
+            schedule_id=schedule_id, orchestration_mode=orchestration_mode,
+            run_id=run_id,
+        )
         return result
     finally:
         agents_running.labels(namespace=namespace_name).dec()
@@ -917,6 +953,9 @@ async def _post_orchestration(
     trigger_type: str,
     result: OrchestrationResult,
     tool_call_records: list[dict] | None = None,
+    schedule_id: str | None = None,
+    orchestration_mode: str | None = None,
+    run_id: str | None = None,
 ) -> None:
     """Handle post-orchestration tasks: auto_channel, run recording."""
     if result.success and agent.auto_channel and result.final_text:
@@ -925,7 +964,32 @@ async def _post_orchestration(
         except Exception:
             logger.exception("auto_channel_send_failed", agent_name=agent.name)
 
-    await _record_run(agent, trigger_type, result, tool_call_records=tool_call_records)
+    await _record_run(
+        agent, trigger_type, result, tool_call_records=tool_call_records,
+        schedule_id=schedule_id, orchestration_mode=orchestration_mode,
+        run_id=run_id,
+    )
+
+    import asyncio as _aio
+
+    from mcpworks_api.services.telemetry import emit_orchestration_run_event
+
+    _aio.create_task(
+        emit_orchestration_run_event(
+            namespace_id=agent.namespace_id,
+            namespace_name=agent.name,
+            agent_name=agent.name,
+            run_id=run_id or "",
+            trigger_type=trigger_type,
+            orchestration_mode=orchestration_mode,
+            outcome=result.outcome,
+            duration_ms=result.duration_ms,
+            functions_called_count=len(result.functions_called),
+            limits_consumed=result.limits_consumed,
+            limits_configured=result.limits_configured,
+            error=result.error,
+        )
+    )
 
 
 async def _record_run(
@@ -933,9 +997,21 @@ async def _record_run(
     trigger_type: str,
     result: OrchestrationResult,
     tool_call_records: list[dict] | None = None,
+    schedule_id: str | None = None,
+    orchestration_mode: str | None = None,
+    run_id: str | None = None,
 ) -> None:
     """Record an orchestration run as an AgentRun with tool call audit trail."""
-    status = "completed" if result.success else "failed"
+    status_map = {
+        "completed": "completed",
+        "no_action": "no_action",
+        "limit_hit": "limit_hit",
+        "error": "failed",
+        "timeout": "timeout",
+        "cancelled": "cancelled",
+    }
+    outcome = result.outcome or ("completed" if result.success else "error")
+    status = status_map.get(outcome, "failed")
     record_agent_run(
         namespace=agent.name,
         trigger_type=trigger_type,
@@ -944,15 +1020,30 @@ async def _record_run(
         iterations=result.iterations or 0,
     )
     try:
+        import uuid as _uuid_mod
+
         from mcpworks_api.models.agent_tool_call import AgentToolCall
 
+        sched_uuid = _uuid_mod.UUID(schedule_id) if schedule_id else None
+        run_uuid = _uuid_mod.UUID(run_id) if run_id else None
+
         async with get_db_context() as db:
+            run_kwargs: dict = {}
+            if run_uuid:
+                run_kwargs["id"] = run_uuid
             run = AgentRun(
                 agent_id=agent.id,
+                **run_kwargs,
                 trigger_type="ai",
                 trigger_detail=f"orchestration:{trigger_type}",
                 function_name=", ".join(result.functions_called[:10]) or None,
                 status=status,
+                outcome=outcome,
+                orchestration_mode=orchestration_mode,
+                limits_consumed=result.limits_consumed,
+                limits_configured=result.limits_configured,
+                schedule_id=sched_uuid,
+                functions_called_count=len(result.functions_called),
                 started_at=datetime.now(UTC),
                 completed_at=datetime.now(UTC),
                 duration_ms=result.duration_ms,
@@ -1003,7 +1094,14 @@ def _limit_result(
     total_tokens: int,
     start_time: float,
     context_tokens: int = 0,
+    limits: dict | None = None,
 ) -> OrchestrationResult:
+    _consumed = {
+        "iterations": iterations,
+        "ai_tokens": total_tokens,
+        "functions_called": len(functions_called),
+        "execution_seconds": round(_elapsed_seconds(start_time), 1),
+    }
     return OrchestrationResult(
         success=False,
         final_text=None,
@@ -1013,6 +1111,9 @@ def _limit_result(
         duration_ms=_elapsed_ms(start_time),
         error=error,
         context_tokens=context_tokens,
+        outcome="limit_hit",
+        limits_consumed=_consumed,
+        limits_configured=limits,
     )
 
 

--- a/src/mcpworks_api/tasks/retention.py
+++ b/src/mcpworks_api/tasks/retention.py
@@ -1,0 +1,42 @@
+"""Background retention pruning for orchestration observability data."""
+
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import delete
+
+from mcpworks_api.core.database import get_db_context
+from mcpworks_api.models.agent import AgentRun
+from mcpworks_api.models.schedule_fire import ScheduleFire
+
+logger = structlog.get_logger(__name__)
+
+AGENT_RUN_RETENTION_DAYS = 30
+SCHEDULE_FIRE_RETENTION_DAYS = 90
+
+
+async def prune_observability_data() -> None:
+    try:
+        async with get_db_context() as db:
+            run_cutoff = datetime.now(UTC) - timedelta(days=AGENT_RUN_RETENTION_DAYS)
+            result = await db.execute(
+                delete(AgentRun).where(AgentRun.created_at < run_cutoff)
+            )
+            runs_deleted = result.rowcount
+
+            fire_cutoff = datetime.now(UTC) - timedelta(days=SCHEDULE_FIRE_RETENTION_DAYS)
+            result = await db.execute(
+                delete(ScheduleFire).where(ScheduleFire.created_at < fire_cutoff)
+            )
+            fires_deleted = result.rowcount
+
+        if runs_deleted or fires_deleted:
+            logger.info(
+                "observability_retention_pruned",
+                runs_deleted=runs_deleted,
+                fires_deleted=fires_deleted,
+                run_cutoff_days=AGENT_RUN_RETENTION_DAYS,
+                fire_cutoff_days=SCHEDULE_FIRE_RETENTION_DAYS,
+            )
+    except Exception:
+        logger.exception("observability_retention_failed")

--- a/src/mcpworks_api/tasks/retention.py
+++ b/src/mcpworks_api/tasks/retention.py
@@ -19,9 +19,7 @@ async def prune_observability_data() -> None:
     try:
         async with get_db_context() as db:
             run_cutoff = datetime.now(UTC) - timedelta(days=AGENT_RUN_RETENTION_DAYS)
-            result = await db.execute(
-                delete(AgentRun).where(AgentRun.created_at < run_cutoff)
-            )
+            result = await db.execute(delete(AgentRun).where(AgentRun.created_at < run_cutoff))
             runs_deleted = result.rowcount
 
             fire_cutoff = datetime.now(UTC) - timedelta(days=SCHEDULE_FIRE_RETENTION_DAYS)

--- a/src/mcpworks_api/tasks/scheduler.py
+++ b/src/mcpworks_api/tasks/scheduler.py
@@ -24,6 +24,7 @@ from mcpworks_api.core.database import get_db_context
 from mcpworks_api.models.account import Account
 from mcpworks_api.models.agent import Agent, AgentReplica, AgentRun, AgentSchedule, ScheduledJob
 from mcpworks_api.models.namespace import Namespace
+from mcpworks_api.models.schedule_fire import ScheduleFire
 from mcpworks_api.services.agent_service import AgentService
 from mcpworks_api.services.function import FunctionService
 
@@ -201,7 +202,19 @@ async def _execute_scheduled_function(
     agent: Agent,
 ) -> None:
     """Execute a single scheduled function, respecting orchestration_mode."""
+    from mcpworks_api.middleware.observability import record_schedule_fire
     from mcpworks_api.tasks.orchestrator import run_orchestration
+
+    fire_id = uuid_mod.uuid4()
+    async with get_db_context() as db:
+        fire = ScheduleFire(
+            id=fire_id,
+            schedule_id=schedule.id,
+            agent_id=agent.id,
+            status="started",
+        )
+        db.add(fire)
+    record_schedule_fire(namespace=agent.name, status="started")
 
     orch_mode = getattr(schedule, "orchestration_mode", "direct") or "direct"
 
@@ -275,6 +288,8 @@ async def _execute_scheduled_function(
         trigger_data={"schedule_id": str(schedule.id), "function_name": schedule.function_name},
         tier=tier,
         account=account,
+        schedule_id=str(schedule.id),
+        orchestration_mode=orch_mode,
     )
 
     async with get_db_context() as db:
@@ -287,6 +302,16 @@ async def _execute_scheduled_function(
                 else schedule.consecutive_failures + 1,
                 last_run_at=datetime.now(UTC),
                 next_run_at=_compute_next_run(schedule.cron_expression, schedule.timezone),
+            )
+        )
+
+    async with get_db_context() as db:
+        await db.execute(
+            update(ScheduleFire)
+            .where(ScheduleFire.id == fire_id)
+            .values(
+                status="started" if orch_result.success else "error",
+                error_detail=orch_result.error[:500] if orch_result.error else None,
             )
         )
 

--- a/tests/unit/test_execution_service.py
+++ b/tests/unit/test_execution_service.py
@@ -22,6 +22,7 @@ class FakeExecution:
             "error_code": None,
             "backend_metadata": None,
             "created_at": None,
+            "agent_run_id": None,
         }
         defaults.update(kwargs)
         for k, v in defaults.items():


### PR DESCRIPTION
## Summary

- Make the orchestration pipeline visible end-to-end: every cron fire, orchestration run, AI decision step, and function execution is now recorded and queryable
- Fix a run ID mismatch bug where execution records pointed to a UUID that didn't exist in `agent_runs` — execution→run correlation now works
- Add structured decision logs (enum-only, no free text) to prevent PII exposure from ingested tool results
- Add `orchestration_run` telemetry webhook event type for push-based monitoring

## What's included

| Layer | What | How to query |
|-------|------|-------------|
| Cron fires | Every schedule fire recorded with status/error | `list_schedule_fires` MCP tool, `GET /v1/schedules/{id}/fires` |
| Orchestration runs | Outcome, limits consumed/configured, mode, steps | `list_orchestration_runs` / `describe_orchestration_run` MCP tools, `GET /v1/agents/{id}/runs` |
| Decision steps | Structured decision_type + reason_category per step | Included in `describe_orchestration_run` response |
| Execution correlation | Bidirectional: execution→run and run→executions | `agent_run_id` on execution detail, `executions` list on run detail |
| Webhook push | Opt-in `orchestration_run` event type | `configure_telemetry_webhook(events=['tool_call','orchestration_run'])` |
| Retention | 30-day runs, 90-day fires, daily background pruning | Automatic |
| Metrics | `mcpworks_schedule_fires_total` Prometheus counter | `/metrics` |

## Spec artifacts

Full speckit pipeline: `specs/027-orchestration-observability/` (spec, clarifications, plan, research, data model, contracts, tasks)

## Test plan

- [x] `pytest tests/unit/ -q` — 649 passed, 0 failures
- [x] `ruff check` — all modified files clean
- [ ] Deploy to staging and trigger mcpworkssocial cron schedules
- [ ] Query `list_orchestration_runs(agent='mcpworkssocial')` and verify runs appear with outcomes
- [ ] Query `list_schedule_fires(agent='mcpworkssocial')` and verify fire history
- [ ] Use `describe_orchestration_run` to inspect steps and limits
- [ ] Verify `describe_execution` now includes `agent_run_id`
- [ ] Configure telemetry webhook with `orchestration_run` event and verify delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)