### PR TITLE
Function result caching via Redis (#44)

### DIFF
--- a/alembic/versions/20260415_000002_add_function_cache_policy.py
+++ b/alembic/versions/20260415_000002_add_function_cache_policy.py
@@ -1,0 +1,26 @@
+"""Add cache_policy JSONB to functions for result caching configuration.
+
+Revision ID: 20260415_000002
+Revises: 20260415_000001
+Create Date: 2026-04-15
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20260415_000002"
+down_revision = "20260415_000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "functions",
+        sa.Column("cache_policy", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("functions", "cache_policy")

--- a/specs/029-function-result-cache/checklists/requirements.md
+++ b/specs/029-function-result-cache/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Function Result Caching (Redis)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Ready for `/speckit.plan`.
+- Cache policy stored on existing model config field — no migration needed.
+- Graceful Redis degradation is a key requirement, not optional.

--- a/specs/029-function-result-cache/plan.md
+++ b/specs/029-function-result-cache/plan.md
@@ -1,0 +1,48 @@
+# Implementation Plan: Function Result Caching (Redis)
+
+**Branch**: `029-function-result-cache` | **Date**: 2026-04-15 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Add opt-in result caching for function executions using Redis. Cache keys derived from function_id + version + hash(input). Check Redis before sandbox dispatch in run_handler, store on success, skip on error. Per-function cache_policy JSONB column. Prometheus metrics for hit/miss. Graceful degradation when Redis is unavailable.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (existing)
+**Primary Dependencies**: FastAPI, SQLAlchemy 2.0+ async, redis.asyncio (existing)
+**Storage**: PostgreSQL (new cache_policy JSONB on functions), Redis (cache entries)
+**Testing**: pytest unit tests
+**Performance Goals**: Cache hits < 50ms, graceful Redis failure
+**Constraints**: No thundering herd protection v1, no cross-namespace sharing
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-First | PASS | Full spec completed |
+| II. Token Efficiency | PASS | Cached responses eliminate redundant sandbox execution |
+| III. Transaction Safety | PASS | Cache is best-effort, never blocks execution |
+| IV. Observability | PASS | Prometheus hit/miss counters, execution metadata |
+| V. API Contracts | PASS | Cache bypass via existing input mechanism |
+
+## Project Structure
+
+```text
+src/mcpworks_api/
+├── services/
+│   └── result_cache.py        # NEW — cache check/store/key generation
+├── mcp/
+│   ├── run_handler.py          # MODIFIED — inject cache layer before execute
+│   ├── create_handler.py       # MODIFIED — configure_cache handler
+│   └── tool_registry.py        # MODIFIED — configure_cache tool definition
+├── models/
+│   └── function.py             # MODIFIED — cache_policy JSONB column
+└── middleware/
+    └── execution_metrics.py    # MODIFIED — cache hit/miss counters
+
+alembic/versions/
+└── 20260415_000002_*.py        # NEW — add cache_policy to functions
+
+tests/unit/
+└── test_result_cache.py        # NEW — cache key generation, policy parsing
+```

--- a/specs/029-function-result-cache/spec.md
+++ b/specs/029-function-result-cache/spec.md
@@ -1,0 +1,101 @@
+# Feature Specification: Function Result Caching (Redis)
+
+**Feature Branch**: `029-function-result-cache`  
+**Created**: 2026-04-15  
+**Status**: Draft  
+**Input**: User description: "#44 — Function result caching (Redis). Cache function results by function_id + hash(input) in Redis with configurable per-function TTL."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Cache deterministic function results (Priority: P1)
+
+A namespace owner has a deterministic function (e.g., currency conversion, template rendering) that gets called repeatedly with the same inputs. They enable caching on the function with a TTL of 5 minutes. Subsequent identical calls within the TTL window return instantly from Redis without spinning up a sandbox, saving compute and reducing latency from seconds to milliseconds.
+
+**Why this priority**: This is the core value — latency reduction and compute savings for repeat calls. Without this, the feature has no purpose.
+
+**Independent Test**: Call a cached function twice with identical inputs. First call executes in sandbox (~2s). Second call returns from cache (~10ms). Both return identical output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a function with caching enabled (TTL 300s), **When** it is called twice with the same input within 300s, **Then** the second call returns the cached result without sandbox execution, with latency under 50ms.
+2. **Given** a function with caching enabled, **When** it is called and execution fails (error result), **Then** the error is NOT cached — the next call executes fresh.
+3. **Given** a function with caching enabled, **When** it is called with different inputs, **Then** each unique input set gets its own cache entry.
+4. **Given** a function with caching disabled (default), **When** it is called, **Then** every call goes to sandbox — no cache interaction.
+
+---
+
+### User Story 2 - Caller bypasses cache (Priority: P2)
+
+A caller needs a fresh result for a cached function (e.g., testing a code change, debugging stale data). They pass a `cache: false` flag in the function call to force fresh execution and update the cache with the new result.
+
+**Why this priority**: Essential escape hatch — without bypass, stale cache is unfixable until TTL expires.
+
+**Independent Test**: Call a cached function with `cache: false`. Verify sandbox execution occurs even when a cached result exists, and the cache is updated with the fresh result.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cached result exists for a function+input pair, **When** the caller passes `cache: false`, **Then** the function executes in sandbox and the cache is updated with the new result.
+
+---
+
+### User Story 3 - Cache hit/miss observability (Priority: P3)
+
+An operator wants to understand cache effectiveness across functions. Cache hits and misses are tracked as Prometheus metrics, and cache status is included in execution metadata so it's visible in execution history.
+
+**Why this priority**: Without observability, operators can't measure whether caching is actually helping or needs tuning.
+
+**Independent Test**: After a cache hit, verify the Prometheus cache_hits counter incremented and the execution record shows `cache_hit: true`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cache hit occurs, **When** metrics are scraped, **Then** the `function_cache_hits_total` counter has incremented with namespace and function labels.
+2. **Given** a cache miss followed by execution, **When** the execution record is examined, **Then** it includes cache status metadata (hit/miss).
+
+---
+
+### Edge Cases
+
+- What happens when Redis is down? Function executes normally without caching — Redis failure must never block execution.
+- What happens when the cached result is corrupted (invalid JSON)? Treat as cache miss, execute fresh, overwrite the corrupt entry.
+- What happens when a function is updated to a new version? Cache keys include the version number, so the old cache is naturally orphaned and expires via TTL.
+- What happens when the cache value exceeds Redis memory? Redis eviction policy handles this — the application does not manage eviction.
+- What happens when two identical calls arrive simultaneously (cold cache)? Both execute — no thundering herd protection for v1 (documented as non-goal).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support per-function cache configuration via a cache policy setting (enabled flag + TTL in seconds).
+- **FR-002**: Cache keys MUST be derived from function ID, active version number, and a deterministic hash of the input parameters.
+- **FR-003**: System MUST check Redis for a cached result before dispatching to the sandbox backend.
+- **FR-004**: System MUST store successful execution results in Redis with the configured TTL after sandbox execution.
+- **FR-005**: System MUST NOT cache error results (only successful executions are cached).
+- **FR-006**: Callers MUST be able to bypass the cache by passing a flag, forcing fresh execution and updating the cache.
+- **FR-007**: Caching MUST be disabled by default — functions only cache when explicitly configured.
+- **FR-008**: System MUST degrade gracefully when Redis is unavailable — function execution proceeds without caching.
+- **FR-009**: System MUST track cache hits and misses as Prometheus counters with namespace and function name labels.
+- **FR-010**: Cache status (hit/miss) MUST be included in execution metadata for observability.
+- **FR-011**: Namespace owners MUST be able to configure cache policy via the MCP create endpoint.
+
+### Key Entities
+
+- **Cache Policy**: Per-function configuration containing `enabled` (boolean) and `ttl_seconds` (integer, default 300). Stored on the function model.
+- **Cache Entry**: A Redis key-value pair where the key encodes function identity + input hash, and the value is the serialized execution result. Expires automatically via Redis TTL.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Cached function calls return in under 50ms (vs 1-5 seconds for sandbox execution).
+- **SC-002**: Cache hit rate for a function called 10 times with identical inputs within TTL window is 90% (9 hits, 1 miss).
+- **SC-003**: Redis failure does not cause any function call to fail — degradation is invisible to the caller.
+- **SC-004**: Cache entries expire automatically at the configured TTL — no manual cleanup required.
+- **SC-005**: Operators can measure cache effectiveness via Prometheus metrics within 24 hours of enabling caching on a function.
+
+## Assumptions
+
+- Redis is already deployed and connected in all environments (production, development).
+- The existing `config` JSONB field on the Function model can be extended to include cache policy, avoiding a schema migration.
+- Input canonicalization uses sorted JSON serialization for deterministic hashing.
+- Cache values are stored as JSON strings in Redis — the serialized ExecutionResult output.
+- No thundering herd protection in v1 — simultaneous cold-cache calls all execute. This is acceptable given the expected call volume.

--- a/src/mcpworks_api/mcp/create_handler.py
+++ b/src/mcpworks_api/mcp/create_handler.py
@@ -177,6 +177,7 @@ class CreateMCPHandler:
         "remove_security_scanner": "write",
         "configure_telemetry_webhook": "write",
         "configure_discovery": "write",
+        "configure_cache": "write",
         "list_orchestration_runs": "read",
         "describe_orchestration_run": "read",
         "list_schedule_fires": "read",
@@ -544,6 +545,7 @@ class CreateMCPHandler:
             "remove_security_scanner": self._remove_security_scanner,
             "configure_telemetry_webhook": self._configure_telemetry_webhook,
             "configure_discovery": self._configure_discovery,
+            "configure_cache": self._configure_cache,
             "list_orchestration_runs": self._list_orchestration_runs,
             "describe_orchestration_run": self._describe_orchestration_run,
             "list_schedule_fires": self._list_schedule_fires,
@@ -3484,6 +3486,58 @@ class CreateMCPHandler:
                             "namespace": ns.name,
                             "discoverable": ns.discoverable,
                             "server_card_url": f"https://{ns.name}.create.mcpworks.io/.well-known/mcp.json",
+                        }
+                    )
+                )
+            ]
+        )
+
+    async def _configure_cache(
+        self,
+        service: str,
+        function: str,
+        enabled: bool,
+        ttl_seconds: int = 300,
+    ) -> MCPToolResult:
+        from sqlalchemy import select
+
+        from mcpworks_api.models.function import Function
+        from mcpworks_api.models.namespace_service import NamespaceService
+
+        ns = await self._get_current_namespace()
+        svc_result = await self.db.execute(
+            select(NamespaceService).where(
+                NamespaceService.namespace_id == ns.id,
+                NamespaceService.name == service,
+            )
+        )
+        svc = svc_result.scalar_one_or_none()
+        if not svc:
+            raise ValueError(f"Service '{service}' not found")
+
+        fn_result = await self.db.execute(
+            select(Function).where(
+                Function.service_id == svc.id,
+                Function.name == function,
+                Function.deleted_at.is_(None),
+            )
+        )
+        fn = fn_result.scalar_one_or_none()
+        if not fn:
+            raise ValueError(f"Function '{function}' not found in service '{service}'")
+
+        ttl_seconds = max(1, min(86400, ttl_seconds))
+        fn.cache_policy = {"enabled": enabled, "ttl_seconds": ttl_seconds} if enabled else None
+        await self.db.flush()
+
+        return MCPToolResult(
+            content=[
+                MCPContent(
+                    text=json.dumps(
+                        {
+                            "function": f"{service}.{function}",
+                            "cache_enabled": enabled,
+                            "ttl_seconds": ttl_seconds if enabled else None,
                         }
                     )
                 )

--- a/src/mcpworks_api/mcp/run_handler.py
+++ b/src/mcpworks_api/mcp/run_handler.py
@@ -347,20 +347,66 @@ class RunMCPHandler:
 
         agent_context = await self._load_agent_context(namespace)
 
+        from mcpworks_api.services.result_cache import (
+            get_cache_policy,
+            get_cached_result,
+            make_cache_key,
+            set_cached_result,
+        )
+
+        cache_enabled, cache_ttl = get_cache_policy(function)
+        cache_bypass = arguments.pop("cache", None) is False if arguments else False
+        cache_hit = False
+        cache_key = None
+
+        if cache_enabled and not cache_bypass:
+            cache_key = make_cache_key(str(function.id), version.version, arguments)
+            cached = await get_cached_result(cache_key)
+            if cached is not None:
+                cache_hit = True
+                from mcpworks_api.backends.base import ExecutionResult
+
+                result = ExecutionResult(
+                    success=True,
+                    output=cached,
+                    stdout=None,
+                    stderr=None,
+                    error=None,
+                    error_type=None,
+                    execution_time_ms=0,
+                )
+                from mcpworks_api.middleware.execution_metrics import function_cache_total
+
+                function_cache_total.labels(
+                    namespace=self.namespace_name, function=name, result="hit"
+                ).inc()
+        elif cache_enabled:
+            cache_key = make_cache_key(str(function.id), version.version, arguments)
+
         execution_id = str(uuid.uuid4())
         start_time = datetime.now(UTC)
 
-        result = await backend.execute(
-            code=version.code,
-            config=version.config,
-            input_data=arguments,
-            account=self.account,
-            execution_id=execution_id,
-            sandbox_env=filtered_env,
-            context=agent_context,
-            language=getattr(version, "language", "python"),
-            namespace=self.namespace_name,
-        )
+        if not cache_hit:
+            result = await backend.execute(
+                code=version.code,
+                config=version.config,
+                input_data=arguments,
+                account=self.account,
+                execution_id=execution_id,
+                sandbox_env=filtered_env,
+                context=agent_context,
+                language=getattr(version, "language", "python"),
+                namespace=self.namespace_name,
+            )
+
+            if cache_enabled:
+                from mcpworks_api.middleware.execution_metrics import function_cache_total
+
+                function_cache_total.labels(
+                    namespace=self.namespace_name, function=name, result="miss"
+                ).inc()
+                if result.success and cache_key:
+                    asyncio.create_task(set_cached_result(cache_key, result.output, cache_ttl))
 
         execution_time_ms = result.execution_time_ms or int(
             (datetime.now(UTC) - start_time).total_seconds() * 1000
@@ -374,6 +420,7 @@ class RunMCPHandler:
             execution_time_ms=execution_time_ms,
             execution_id=execution_id,
             success=result.success,
+            cache_hit=cache_hit,
         )
 
         await self._persist_execution_record(

--- a/src/mcpworks_api/mcp/tool_registry.py
+++ b/src/mcpworks_api/mcp/tool_registry.py
@@ -446,6 +446,38 @@ BASE_TOOLS: dict[str, ToolDef] = {
             "required": ["name"],
         },
     ),
+    "configure_cache": ToolDef(
+        name="configure_cache",
+        brief="Enable or disable result caching for a function.",
+        description=(
+            "Configure Redis-backed result caching for a function. "
+            "When enabled, identical inputs return cached results instantly "
+            "instead of re-executing in sandbox. Only successful results are cached. "
+            "Example: configure_cache(service='utils', function='convert', enabled=true, ttl_seconds=600)."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "service": {
+                    "type": "string",
+                    "description": "Service name containing the function.",
+                },
+                "function": {
+                    "type": "string",
+                    "description": "Function name to configure caching for.",
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "True to enable caching, false to disable.",
+                },
+                "ttl_seconds": {
+                    "type": "integer",
+                    "description": "Cache TTL in seconds (default: 300, max: 86400).",
+                },
+            },
+            "required": ["service", "function", "enabled"],
+        },
+    ),
     "configure_discovery": ToolDef(
         name="configure_discovery",
         brief="Toggle namespace visibility in MCP server card discovery.",

--- a/src/mcpworks_api/middleware/execution_metrics.py
+++ b/src/mcpworks_api/middleware/execution_metrics.py
@@ -6,6 +6,12 @@ from typing import Any
 
 from prometheus_client import Counter, Gauge, Histogram
 
+function_cache_total = Counter(
+    "mcpworks_function_cache_total",
+    "Function result cache hits and misses",
+    ["namespace", "function", "result"],
+)
+
 sandbox_executions_total = Counter(
     "sandbox_executions_total",
     "Total sandbox executions",

--- a/src/mcpworks_api/models/function.py
+++ b/src/mcpworks_api/models/function.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 
 from mcpworks_api.models.base import Base, TimestampMixin, UUIDMixin
@@ -106,6 +106,8 @@ class Function(Base, UUIDMixin, TimestampMixin):
         server_default="false",
         nullable=False,
     )
+
+    cache_policy: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     deleted_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),

--- a/src/mcpworks_api/services/result_cache.py
+++ b/src/mcpworks_api/services/result_cache.py
@@ -1,0 +1,48 @@
+"""Function result caching via Redis."""
+
+import hashlib
+import json
+
+import structlog
+
+from mcpworks_api.core.redis import get_redis_context
+
+logger = structlog.get_logger(__name__)
+
+
+def make_cache_key(function_id: str, version: int, input_data: dict | None) -> str:
+    canonical = json.dumps(input_data or {}, sort_keys=True, separators=(",", ":"))
+    input_hash = hashlib.sha256(canonical.encode()).hexdigest()[:16]
+    return f"fncache:{function_id}:v{version}:{input_hash}"
+
+
+def get_cache_policy(function) -> tuple[bool, int]:
+    policy = getattr(function, "cache_policy", None)
+    if not policy or not isinstance(policy, dict):
+        return False, 0
+    enabled = policy.get("enabled", False)
+    ttl = policy.get("ttl_seconds", 300)
+    if not enabled or ttl <= 0:
+        return False, 0
+    return True, ttl
+
+
+async def get_cached_result(cache_key: str) -> dict | None:
+    try:
+        async with get_redis_context() as redis:
+            raw = await redis.get(cache_key)
+            if raw is None:
+                return None
+            return json.loads(raw)
+    except Exception:
+        logger.warning("result_cache_get_error", cache_key=cache_key)
+        return None
+
+
+async def set_cached_result(cache_key: str, result_output, ttl_seconds: int) -> None:
+    try:
+        value = json.dumps(result_output)
+        async with get_redis_context() as redis:
+            await redis.set(cache_key, value, ex=ttl_seconds)
+    except Exception:
+        logger.warning("result_cache_set_error", cache_key=cache_key)

--- a/tests/unit/test_result_cache.py
+++ b/tests/unit/test_result_cache.py
@@ -1,0 +1,90 @@
+"""Unit tests for function result cache key generation and policy parsing."""
+
+from mcpworks_api.services.result_cache import get_cache_policy, make_cache_key
+
+
+class TestMakeCacheKey:
+    def test_deterministic_key(self):
+        key1 = make_cache_key("abc-123", 1, {"x": 1, "y": 2})
+        key2 = make_cache_key("abc-123", 1, {"x": 1, "y": 2})
+        assert key1 == key2
+
+    def test_different_inputs_different_keys(self):
+        key1 = make_cache_key("abc-123", 1, {"x": 1})
+        key2 = make_cache_key("abc-123", 1, {"x": 2})
+        assert key1 != key2
+
+    def test_key_order_independent(self):
+        key1 = make_cache_key("abc-123", 1, {"b": 2, "a": 1})
+        key2 = make_cache_key("abc-123", 1, {"a": 1, "b": 2})
+        assert key1 == key2
+
+    def test_different_versions_different_keys(self):
+        key1 = make_cache_key("abc-123", 1, {"x": 1})
+        key2 = make_cache_key("abc-123", 2, {"x": 1})
+        assert key1 != key2
+
+    def test_different_functions_different_keys(self):
+        key1 = make_cache_key("abc-123", 1, {"x": 1})
+        key2 = make_cache_key("def-456", 1, {"x": 1})
+        assert key1 != key2
+
+    def test_none_input(self):
+        key = make_cache_key("abc-123", 1, None)
+        assert key.startswith("fncache:abc-123:v1:")
+
+    def test_empty_input(self):
+        key1 = make_cache_key("abc-123", 1, {})
+        key2 = make_cache_key("abc-123", 1, None)
+        assert key1 == key2
+
+    def test_key_format(self):
+        key = make_cache_key("func-id", 3, {"q": "hello"})
+        assert key.startswith("fncache:func-id:v3:")
+        assert len(key.split(":")) == 4
+
+
+class FakeFunction:
+    def __init__(self, cache_policy=None):
+        self.cache_policy = cache_policy
+
+
+class TestGetCachePolicy:
+    def test_no_policy(self):
+        fn = FakeFunction()
+        enabled, ttl = get_cache_policy(fn)
+        assert enabled is False
+        assert ttl == 0
+
+    def test_none_policy(self):
+        fn = FakeFunction(cache_policy=None)
+        enabled, ttl = get_cache_policy(fn)
+        assert enabled is False
+
+    def test_enabled_policy(self):
+        fn = FakeFunction(cache_policy={"enabled": True, "ttl_seconds": 600})
+        enabled, ttl = get_cache_policy(fn)
+        assert enabled is True
+        assert ttl == 600
+
+    def test_disabled_policy(self):
+        fn = FakeFunction(cache_policy={"enabled": False, "ttl_seconds": 300})
+        enabled, ttl = get_cache_policy(fn)
+        assert enabled is False
+        assert ttl == 0
+
+    def test_default_ttl(self):
+        fn = FakeFunction(cache_policy={"enabled": True})
+        enabled, ttl = get_cache_policy(fn)
+        assert enabled is True
+        assert ttl == 300
+
+    def test_zero_ttl_disables(self):
+        fn = FakeFunction(cache_policy={"enabled": True, "ttl_seconds": 0})
+        enabled, ttl = get_cache_policy(fn)
+        assert enabled is False
+
+    def test_invalid_policy_type(self):
+        fn = FakeFunction(cache_policy="invalid")
+        enabled, ttl = get_cache_policy(fn)
+        assert enabled is False


### PR DESCRIPTION
## Summary

- Opt-in per-function result caching backed by Redis
- Cache key: `fncache:{function_id}:v{version}:{sha256(input)[:16]}`
- Only successful results cached; errors always execute fresh
- Redis failures degrade gracefully — execution proceeds uncached
- `configure_cache` MCP tool for namespace owners to enable/disable + set TTL
- `cache: false` input flag lets callers bypass cache
- Prometheus counter `mcpworks_function_cache_total` with hit/miss labels

## Test plan

- [ ] Enable caching on a function: `configure_cache(service='monitor', function='check-api', enabled=true, ttl_seconds=300)`
- [ ] Call function twice with same input — second call should return in <50ms
- [ ] Call with `cache: false` — should execute fresh
- [ ] Error results should not be cached
- [ ] 673 unit tests pass (15 new cache tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)