### PR TITLE
Tag-filtered tools/list for MCP run endpoint (#41)

### DIFF
--- a/specs/030-tag-filtered-tools/checklists/requirements.md
+++ b/specs/030-tag-filtered-tools/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Tag-Filtered Tools List
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. No schema changes needed — functions already have tags.
+- Key design decision: visibility filter only, not access control.
+- Case-insensitive matching specified in FR-005.

--- a/specs/030-tag-filtered-tools/plan.md
+++ b/specs/030-tag-filtered-tools/plan.md
@@ -1,0 +1,38 @@
+# Implementation Plan: Tag-Filtered Tools List
+
+**Branch**: `030-tag-filtered-tools` | **Date**: 2026-04-15 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Add `tags` query parameter to MCP run endpoint. When provided, `tools/list` returns only functions matching any of the specified tags (OR semantics). No tags = all functions (backward compatible). Visibility filter only — `tools/call` is unaffected. No schema changes needed.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (existing)
+**Primary Dependencies**: FastAPI, SQLAlchemy (existing)
+**Storage**: No changes — functions already have `tags` ARRAY field
+**Testing**: pytest unit tests
+**Constraints**: Zero latency impact (in-memory filter), fully backward compatible
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-First | PASS | Full spec completed |
+| II. Token Efficiency | PASS | This feature directly reduces token usage by filtering tool lists |
+| III. Transaction Safety | N/A | Read-only filter, no state changes |
+| IV. Observability | PASS | Existing structured logging covers tools/list |
+| V. API Contracts | PASS | Additive query parameter, no breaking changes |
+
+## Project Structure
+
+```text
+src/mcpworks_api/mcp/
+├── router.py           # MODIFIED — extract tags from request, pass to handler
+└── run_handler.py      # MODIFIED — accept tag_filter, filter in get_tools()
+
+tests/unit/
+└── test_tag_filter.py  # NEW — tag filtering logic tests
+```
+
+No new files, services, models, or migrations. Two modified files + one test file.

--- a/specs/030-tag-filtered-tools/spec.md
+++ b/specs/030-tag-filtered-tools/spec.md
@@ -1,0 +1,76 @@
+# Feature Specification: Tag-Filtered Tools List
+
+**Feature Branch**: `030-tag-filtered-tools`  
+**Created**: 2026-04-15  
+**Status**: Draft  
+**Input**: User description: "#41 — Filter visible functions by tag in MCP config. Allow MCP clients to pass a tags query parameter to filter which functions appear in tools/list."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Filter tools/list by tag (Priority: P1)
+
+A namespace owner has 36 functions in `mcpworkssocial/social` but wants a specific agent to only see the 5 Bluesky-related functions. They configure the MCP connection URL with a `tags` query parameter. When the agent connects and requests `tools/list`, it only sees the functions tagged with the specified tags — reducing context window usage and improving tool selection accuracy.
+
+**Why this priority**: This is the entire feature. Tag filtering on the tool list is the core and only user-facing change.
+
+**Independent Test**: Connect to a namespace with `?tags=bluesky` and verify `tools/list` returns only functions tagged `bluesky`, while omitting untagged functions or functions with other tags.
+
+**Acceptance Scenarios**:
+
+1. **Given** a namespace with 10 functions where 3 are tagged "bluesky", **When** a client connects with `?tags=bluesky` and requests `tools/list`, **Then** only the 3 bluesky-tagged functions appear in the response.
+2. **Given** a client connects with `?tags=bluesky,monitoring`, **When** `tools/list` is requested, **Then** functions tagged with EITHER "bluesky" OR "monitoring" appear (OR filter, not AND).
+3. **Given** a client connects with no `tags` parameter, **When** `tools/list` is requested, **Then** ALL functions appear (full backward compatibility).
+4. **Given** a client connects with `?tags=nonexistent`, **When** `tools/list` is requested, **Then** zero user functions appear (only system tools like `_env_status` remain).
+5. **Given** a function has multiple tags including "bluesky", **When** the client filters by `?tags=bluesky`, **Then** that function appears in the list.
+
+---
+
+### User Story 2 - Tag filter applies only to tools/list, not tools/call (Priority: P2)
+
+A caller filters tools/list by tag to reduce context, but can still call any function by name — the tag filter is a visibility filter, not an access control mechanism. This prevents the tag filter from accidentally blocking legitimate function calls.
+
+**Why this priority**: Important correctness guarantee. If tag filtering blocked execution, it would break cross-function calls and procedures that invoke unfiltered functions.
+
+**Independent Test**: Connect with `?tags=bluesky`, then call a function that is NOT tagged "bluesky" by name. Verify it executes successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** a client connected with `?tags=bluesky`, **When** the client calls `social.send-discord-report` (which is not tagged "bluesky"), **Then** the function executes normally — tag filtering is visibility only.
+
+---
+
+### Edge Cases
+
+- What happens when tags parameter is empty string (`?tags=`)? Treat as no filter — show all functions.
+- What happens when tags contain whitespace (`?tags= bluesky , social `)? Trim whitespace from each tag.
+- What happens when tags parameter appears multiple times (`?tags=a&tags=b`)? Combine all values as OR filter.
+- What happens with the SSE transport (not just JSON-RPC POST)? Tags are on the URL, so they apply to the SSE session for the entire connection lifetime.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The MCP run endpoint MUST accept an optional `tags` query parameter containing a comma-separated list of tag names.
+- **FR-002**: When `tags` is provided, `tools/list` MUST return only functions that have at least one matching tag (OR semantics).
+- **FR-003**: When `tags` is not provided or is empty, `tools/list` MUST return all functions (backward compatible).
+- **FR-004**: Tag filtering MUST NOT affect `tools/call` — any function can be called by name regardless of the tag filter.
+- **FR-005**: Tag matching MUST be case-insensitive.
+- **FR-006**: System tools (e.g., `_env_status`) MUST always appear in `tools/list` regardless of tag filter.
+
+### Key Entities
+
+- **Tag Filter**: A set of tag strings extracted from the URL query parameter, applied as an OR filter against function tags during `tools/list` generation. Not persisted — it's a per-connection runtime filter.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A namespace with 36 functions filtered to 5 tags reduces the `tools/list` response size by at least 80%.
+- **SC-002**: Existing MCP connections without `tags` parameter continue to work identically — zero breaking changes.
+- **SC-003**: Tag filtering adds no measurable latency to `tools/list` responses (filtering is in-memory, not a database query change).
+
+## Assumptions
+
+- Functions already have a `tags` array field (ARRAY(String), nullable) in the data model — no schema changes needed.
+- The tag filter is extracted from URL query parameters, which are preserved across the MCP session (SSE connections maintain the original URL).
+- This is a visibility filter, not a security mechanism — it reduces noise, not access.

--- a/specs/030-tag-filtered-tools/tasks.md
+++ b/specs/030-tag-filtered-tools/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: Tag-Filtered Tools List
+
+**Input**: Design documents from `/specs/030-tag-filtered-tools/`
+
+## Phase 1: Setup
+
+- [ ] T001 [P] Unit tests for tag filtering logic (OR semantics, case-insensitive, empty tags, no-match, multi-tag functions) in tests/unit/test_tag_filter.py
+
+## Phase 2: User Story 1 — Filter tools/list by tag (P1) MVP
+
+- [ ] T002 [US1] Add `tag_filter` parameter to RunMCPHandler.__init__ and filter functions in get_tools() — only include functions where any tag matches (case-insensitive OR); system tools always included in src/mcpworks_api/mcp/run_handler.py
+- [ ] T003 [US1] Extract `tags` query parameter from request in MCP router and pass to RunMCPHandler constructor in src/mcpworks_api/mcp/router.py
+
+## Phase 3: Polish
+
+- [ ] T004 Run ruff format and ruff check on all modified files
+- [ ] T005 Run full unit test suite (`pytest tests/unit/ -q`) and verify no regressions
+
+## Dependencies
+
+- T001 can run in parallel with nothing (test-first)
+- T002 depends on understanding the filter contract from T001
+- T003 depends on T002 (handler must accept the parameter)
+- T004-T005 depend on all implementation complete
+
+## Notes
+
+- 5 tasks total. Minimal feature — 2 modified files, 1 new test file, no migrations.

--- a/src/mcpworks_api/mcp/router.py
+++ b/src/mcpworks_api/mcp/router.py
@@ -287,11 +287,16 @@ async def handle_mcp_request(
             api_key=api_key,
         )
     else:  # endpoint_type == "run"
+        tags_raw = request.query_params.get("tags", "")
+        tag_filter = (
+            {t.strip().lower() for t in tags_raw.split(",") if t.strip()} if tags_raw else None
+        )
         handler = RunMCPHandler(
             namespace=namespace_name,
             account=account,
             db=db,
             api_key=api_key,
+            tag_filter=tag_filter,
         )
 
     # Handle request

--- a/src/mcpworks_api/mcp/run_handler.py
+++ b/src/mcpworks_api/mcp/run_handler.py
@@ -57,12 +57,14 @@ class RunMCPHandler:
         db: AsyncSession,
         api_key: APIKey,
         mode: str = "code",
+        tag_filter: set[str] | None = None,
     ):
         self.namespace_name = namespace
         self.account = account
         self.db = db
         self.mode = mode
         self.api_key = api_key
+        self.tag_filter: set[str] = tag_filter or set()
         self.namespace_service = NamespaceServiceManager(db)
         self.function_service = FunctionService(db)
         self._namespace: Namespace | None = None
@@ -148,6 +150,13 @@ class RunMCPHandler:
         tier_notice = self._tier_notice()
         namespace = await self._get_namespace_for_read()
         functions = await self.function_service.list_all_for_namespace(namespace_id=namespace.id)
+
+        if self.tag_filter:
+            functions = [
+                (f, v)
+                for f, v in functions
+                if f.tags and {t.lower() for t in f.tags} & self.tag_filter
+            ]
 
         tools = []
         for func, version in functions:

--- a/tests/unit/test_tag_filter.py
+++ b/tests/unit/test_tag_filter.py
@@ -1,0 +1,109 @@
+"""Unit tests for tag-based function filtering in tools/list."""
+
+
+def filter_by_tags(
+    functions_with_tags: list[tuple[str, list[str] | None]], tag_filter: set[str]
+) -> list[str]:
+    """Reproduce the filtering logic for testing.
+
+    Args:
+        functions_with_tags: List of (function_name, tags) tuples.
+        tag_filter: Set of lowercase tag strings to match against.
+
+    Returns:
+        List of function names that match any tag in the filter.
+    """
+    if not tag_filter:
+        return [name for name, _ in functions_with_tags]
+
+    result = []
+    for name, tags in functions_with_tags:
+        if not tags:
+            continue
+        fn_tags = {t.lower() for t in tags}
+        if fn_tags & tag_filter:
+            result.append(name)
+    return result
+
+
+FUNCTIONS = [
+    ("social.post-to-bluesky", ["bluesky", "social"]),
+    ("social.scan-brave-mentions", ["monitoring", "social"]),
+    ("social.engage-bluesky-feed", ["bluesky"]),
+    ("social.send-discord-report", ["discord", "reporting"]),
+    ("social.find-shareable-news", ["content", "social"]),
+    ("monitor.check-api", ["monitoring", "health"]),
+    ("monitor.canary", None),
+]
+
+
+class TestTagFilter:
+    def test_single_tag_match(self):
+        result = filter_by_tags(FUNCTIONS, {"bluesky"})
+        assert result == ["social.post-to-bluesky", "social.engage-bluesky-feed"]
+
+    def test_multi_tag_or_semantics(self):
+        result = filter_by_tags(FUNCTIONS, {"bluesky", "discord"})
+        assert "social.post-to-bluesky" in result
+        assert "social.engage-bluesky-feed" in result
+        assert "social.send-discord-report" in result
+        assert len(result) == 3
+
+    def test_no_filter_returns_all(self):
+        result = filter_by_tags(FUNCTIONS, set())
+        assert len(result) == len(FUNCTIONS)
+
+    def test_nonexistent_tag_returns_empty(self):
+        result = filter_by_tags(FUNCTIONS, {"nonexistent"})
+        assert result == []
+
+    def test_case_insensitive(self):
+        mixed_case_fns = [
+            ("social.post-to-bluesky", ["Bluesky", "Social"]),
+            ("social.engage-bluesky-feed", ["BLUESKY"]),
+            ("social.send-discord-report", ["Discord"]),
+        ]
+        result = filter_by_tags(mixed_case_fns, {"bluesky"})
+        assert result == ["social.post-to-bluesky", "social.engage-bluesky-feed"]
+
+    def test_function_with_no_tags_excluded(self):
+        result = filter_by_tags(FUNCTIONS, {"monitoring"})
+        assert "monitor.canary" not in result
+        assert "social.scan-brave-mentions" in result
+        assert "monitor.check-api" in result
+
+    def test_function_with_multiple_matching_tags(self):
+        result = filter_by_tags(FUNCTIONS, {"bluesky", "social"})
+        assert "social.post-to-bluesky" in result
+        assert len([r for r in result if r == "social.post-to-bluesky"]) == 1
+
+    def test_broad_tag_returns_many(self):
+        result = filter_by_tags(FUNCTIONS, {"social"})
+        assert len(result) == 3
+
+
+class TestTagParsing:
+    def test_parse_comma_separated(self):
+        raw = "bluesky,social,monitoring"
+        tags = {t.strip().lower() for t in raw.split(",") if t.strip()}
+        assert tags == {"bluesky", "social", "monitoring"}
+
+    def test_parse_with_whitespace(self):
+        raw = " bluesky , social , monitoring "
+        tags = {t.strip().lower() for t in raw.split(",") if t.strip()}
+        assert tags == {"bluesky", "social", "monitoring"}
+
+    def test_parse_empty_string(self):
+        raw = ""
+        tags = {t.strip().lower() for t in raw.split(",") if t.strip()}
+        assert tags == set()
+
+    def test_parse_single_tag(self):
+        raw = "bluesky"
+        tags = {t.strip().lower() for t in raw.split(",") if t.strip()}
+        assert tags == {"bluesky"}
+
+    def test_parse_trailing_comma(self):
+        raw = "bluesky,social,"
+        tags = {t.strip().lower() for t in raw.split(",") if t.strip()}
+        assert tags == {"bluesky", "social"}


### PR DESCRIPTION
## Summary

- MCP clients can pass `?tags=bluesky,social` to filter which functions appear in `tools/list`
- OR semantics — functions matching ANY specified tag are included
- Case-insensitive matching, whitespace-trimmed
- No tags = all functions (fully backward compatible)
- Visibility filter only — `tools/call` is unaffected, any function can still be called by name
- Reduces context window usage for namespaces with many functions

## Test plan

- [ ] Connect with `?tags=monitoring` — only monitoring-tagged functions appear
- [ ] Connect without tags — all functions appear (backward compat)
- [ ] Connect with `?tags=nonexistent` — zero user functions, system tools only
- [ ] Call an unfiltered function by name — still executes
- [ ] 686 unit tests pass (13 new tag filter tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)