### PR TITLE
Schema-driven procedure input/output mappings (#40)

### DIFF
--- a/specs/019-schema-driven-procedures/plan.md
+++ b/specs/019-schema-driven-procedures/plan.md
@@ -1,0 +1,32 @@
+# Implementation Plan: Schema-Driven Procedure Input Mappings
+
+**Branch**: `019-schema-driven-procedures` | **Date**: 2026-04-16 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Add `input_mapping` and `output_mapping` to procedure steps. Input mappings are JSONPath expressions resolved deterministically before presenting the step to the inner AI. Output mappings extract specific fields from step results into accumulated context. Backward compatible — steps without mappings behave as before.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (existing)
+**Primary Dependencies**: No new deps — lightweight JSONPath resolver (stdlib only)
+**Storage**: No migration — steps are JSONB on procedure_versions, new fields are additional dict keys
+**Integration Points**:
+- `orchestrator.py:1255` — resolve input_mapping before AI prompt
+- `orchestrator.py:1399` — apply output_mapping before context accumulation
+- `procedure_service.py:73` — validate mappings at authoring time
+
+## Project Structure
+
+```text
+src/mcpworks_api/
+├── services/
+│   ├── procedure_service.py    # MODIFIED — validate input/output_mapping at authoring
+│   └── jsonpath.py             # NEW — lightweight JSONPath resolver
+├── tasks/
+│   └── orchestrator.py         # MODIFIED — resolve mappings in step loop
+
+tests/unit/
+├── test_jsonpath.py            # NEW — resolver tests
+└── test_procedure_mappings.py  # NEW — mapping validation tests
+```

--- a/src/mcpworks_api/services/jsonpath.py
+++ b/src/mcpworks_api/services/jsonpath.py
@@ -1,0 +1,105 @@
+"""Lightweight JSONPath resolver for procedure step mappings.
+
+Supports a subset of JSONPath sufficient for procedure data flow:
+  $.field           — object field access
+  $.field.nested    — nested field access
+  $.array[0]        — array index access
+  $.steps.name.result.field — step chaining
+"""
+
+import re
+
+_SEGMENT_PATTERN = re.compile(r"([a-zA-Z_][a-zA-Z0-9_-]*)|\[(\d+)\]")
+
+
+class JSONPathError(Exception):
+    pass
+
+
+def resolve(expression: str, context: dict) -> object:
+    if not expression.startswith("$."):
+        raise JSONPathError(f"Expression must start with '$.' — got: {expression}")
+
+    path = expression[2:]
+    if not path:
+        raise JSONPathError("Empty path after '$.'")
+
+    current: object = context
+    segments = _SEGMENT_PATTERN.findall(path)
+
+    raw_remaining = path
+    for field, index in segments:
+        if field:
+            matched = field
+            raw_remaining = raw_remaining[len(matched) :]
+            if raw_remaining.startswith("."):
+                raw_remaining = raw_remaining[1:]
+            if not isinstance(current, dict):
+                raise JSONPathError(
+                    f"Cannot access '{field}' on {type(current).__name__} (at '{expression}')"
+                )
+            if field not in current:
+                raise JSONPathError(f"Key '{field}' not found (at '{expression}')")
+            current = current[field]
+        elif index:
+            matched = f"[{index}]"
+            raw_remaining = raw_remaining[len(matched) :]
+            if raw_remaining.startswith("."):
+                raw_remaining = raw_remaining[1:]
+            idx = int(index)
+            if not isinstance(current, list):
+                raise JSONPathError(
+                    f"Cannot index [{idx}] on {type(current).__name__} (at '{expression}')"
+                )
+            if idx >= len(current):
+                raise JSONPathError(
+                    f"Index [{idx}] out of range (length {len(current)}) (at '{expression}')"
+                )
+            current = current[idx]
+
+    return current
+
+
+def validate_expression(expression: str) -> str | None:
+    if not isinstance(expression, str):
+        return "Expression must be a string"
+    if not expression.startswith("$."):
+        return "Expression must start with '$.'"
+    path = expression[2:]
+    if not path:
+        return "Empty path after '$.'"
+    cleaned = _SEGMENT_PATTERN.sub("", path)
+    cleaned = cleaned.replace(".", "")
+    if cleaned:
+        return f"Invalid characters in path: '{cleaned}'"
+    return None
+
+
+def resolve_input_mapping(
+    mapping: dict[str, str],
+    context: dict,
+) -> tuple[dict, list[str]]:
+    resolved = {}
+    errors = []
+    for param_name, expression in mapping.items():
+        try:
+            resolved[param_name] = resolve(expression, context)
+        except JSONPathError as e:
+            errors.append(f"{param_name}: {e}")
+    return resolved, errors
+
+
+def apply_output_mapping(
+    mapping: dict[str, str],
+    result: object,
+) -> tuple[dict, list[str]]:
+    if not isinstance(result, dict):
+        return {}, [f"Cannot apply output_mapping to {type(result).__name__} result"]
+    extracted = {}
+    errors = []
+    for var_name, expression in mapping.items():
+        try:
+            extracted[var_name] = resolve(expression, result)
+        except JSONPathError as e:
+            errors.append(f"{var_name}: {e}")
+    return extracted, errors

--- a/src/mcpworks_api/services/procedure_service.py
+++ b/src/mcpworks_api/services/procedure_service.py
@@ -71,18 +71,49 @@ class ProcedureService:
                 raise NotFoundError(f"Step {i + 1}: function '{ref}' not found in namespace")
 
         normalized_steps = []
+        step_names_so_far: list[str] = []
         for i, step in enumerate(steps):
-            normalized_steps.append(
-                {
-                    "step_number": i + 1,
-                    "name": step["name"],
-                    "function_ref": step["function_ref"],
-                    "instructions": step["instructions"],
-                    "failure_policy": step.get("failure_policy", "required"),
-                    "max_retries": step.get("max_retries", 1),
-                    "validation": step.get("validation"),
-                }
-            )
+            input_mapping = step.get("input_mapping")
+            output_mapping = step.get("output_mapping")
+
+            if input_mapping and isinstance(input_mapping, dict):
+                from mcpworks_api.services.jsonpath import validate_expression
+
+                for param, expr in input_mapping.items():
+                    error = validate_expression(expr)
+                    if error:
+                        raise ValueError(f"Step {i + 1}: input_mapping['{param}']: {error}")
+                    if expr.startswith("$.steps."):
+                        ref_step = expr.split(".")[2]
+                        if ref_step not in step_names_so_far:
+                            raise ValueError(
+                                f"Step {i + 1}: input_mapping['{param}'] references "
+                                f"step '{ref_step}' which has not executed yet"
+                            )
+
+            if output_mapping and isinstance(output_mapping, dict):
+                from mcpworks_api.services.jsonpath import validate_expression
+
+                for var, expr in output_mapping.items():
+                    error = validate_expression(expr)
+                    if error:
+                        raise ValueError(f"Step {i + 1}: output_mapping['{var}']: {error}")
+
+            step_names_so_far.append(step["name"])
+            normalized_step = {
+                "step_number": i + 1,
+                "name": step["name"],
+                "function_ref": step["function_ref"],
+                "instructions": step["instructions"],
+                "failure_policy": step.get("failure_policy", "required"),
+                "max_retries": step.get("max_retries", 1),
+                "validation": step.get("validation"),
+            }
+            if input_mapping:
+                normalized_step["input_mapping"] = input_mapping
+            if output_mapping:
+                normalized_step["output_mapping"] = output_mapping
+            normalized_steps.append(normalized_step)
 
         procedure = Procedure(
             namespace_id=namespace_id,
@@ -186,18 +217,49 @@ class ProcedureService:
 
         if steps is not None:
             normalized_steps = []
+            step_names_so_far: list[str] = []
             for i, step in enumerate(steps):
-                normalized_steps.append(
-                    {
-                        "step_number": i + 1,
-                        "name": step["name"],
-                        "function_ref": step["function_ref"],
-                        "instructions": step["instructions"],
-                        "failure_policy": step.get("failure_policy", "required"),
-                        "max_retries": step.get("max_retries", 1),
-                        "validation": step.get("validation"),
-                    }
-                )
+                input_mapping = step.get("input_mapping")
+                output_mapping = step.get("output_mapping")
+
+                if input_mapping and isinstance(input_mapping, dict):
+                    from mcpworks_api.services.jsonpath import validate_expression
+
+                    for param, expr in input_mapping.items():
+                        error = validate_expression(expr)
+                        if error:
+                            raise ValueError(f"Step {i + 1}: input_mapping['{param}']: {error}")
+                        if expr.startswith("$.steps."):
+                            ref_step = expr.split(".")[2]
+                            if ref_step not in step_names_so_far:
+                                raise ValueError(
+                                    f"Step {i + 1}: input_mapping['{param}'] references "
+                                    f"step '{ref_step}' which has not executed yet"
+                                )
+
+                if output_mapping and isinstance(output_mapping, dict):
+                    from mcpworks_api.services.jsonpath import validate_expression
+
+                    for var, expr in output_mapping.items():
+                        error = validate_expression(expr)
+                        if error:
+                            raise ValueError(f"Step {i + 1}: output_mapping['{var}']: {error}")
+
+                step_names_so_far.append(step["name"])
+                normalized_step = {
+                    "step_number": i + 1,
+                    "name": step["name"],
+                    "function_ref": step["function_ref"],
+                    "instructions": step["instructions"],
+                    "failure_policy": step.get("failure_policy", "required"),
+                    "max_retries": step.get("max_retries", 1),
+                    "validation": step.get("validation"),
+                }
+                if input_mapping:
+                    normalized_step["input_mapping"] = input_mapping
+                if output_mapping:
+                    normalized_step["output_mapping"] = output_mapping
+                normalized_steps.append(normalized_step)
 
             new_version_num = procedure.active_version + 1
             version = ProcedureVersion(

--- a/src/mcpworks_api/tasks/orchestrator.py
+++ b/src/mcpworks_api/tasks/orchestrator.py
@@ -1224,6 +1224,48 @@ async def run_procedure_orchestration(
 
             fn_schema = await get_function_input_schema(agent.namespace_id, step_db, function_ref)
 
+        input_mapping = step.get("input_mapping")
+        output_mapping = step.get("output_mapping")
+
+        pre_resolved: dict | None = None
+        if input_mapping and isinstance(input_mapping, dict):
+            from mcpworks_api.services.jsonpath import resolve_input_mapping
+
+            pre_resolved, mapping_errors = resolve_input_mapping(input_mapping, accumulated_context)
+            if mapping_errors:
+                step_result_entry: dict = {
+                    "step_number": step_num,
+                    "name": step_name,
+                    "status": "failed",
+                    "function_called": None,
+                    "result": None,
+                    "error": f"Input mapping failed: {'; '.join(mapping_errors)}",
+                    "attempt_count": 0,
+                    "attempts": [],
+                }
+                step_results.append(step_result_entry)
+                if failure_policy == "required":
+                    async with get_db_context() as db:
+                        exec_result = await db.execute(
+                            select(ProcedureExecution).where(ProcedureExecution.id == execution_id)
+                        )
+                        execution_obj = exec_result.scalar_one_or_none()
+                        if execution_obj:
+                            execution_obj.status = "failed"
+                            execution_obj.completed_at = datetime.now(UTC)
+                            execution_obj.step_results = step_results
+
+                    return OrchestrationResult(
+                        success=False,
+                        final_text=f"Procedure failed at step {step_num} ({step_name}): input mapping error",
+                        functions_called=functions_called,
+                        iterations=iterations,
+                        total_tokens=total_tokens,
+                        duration_ms=_elapsed_ms(start_time),
+                        error=f"Input mapping failed: {'; '.join(mapping_errors)}",
+                    )
+                continue
+
         step_result: dict = {
             "step_number": step_num,
             "name": step_name,
@@ -1253,10 +1295,14 @@ async def run_procedure_orchestration(
                 break
 
             ctx_lines = []
+            if pre_resolved:
+                for k, v in pre_resolved.items():
+                    ctx_lines.append(f"  {k} = {json.dumps(v, default=str)} (pre-resolved)")
             input_ctx = accumulated_context.get("input")
             if input_ctx and isinstance(input_ctx, dict):
                 for k, v in input_ctx.items():
-                    ctx_lines.append(f"  {k} = {json.dumps(v, default=str)}")
+                    if not pre_resolved or k not in pre_resolved:
+                        ctx_lines.append(f"  {k} = {json.dumps(v, default=str)}")
             for ctx_key, ctx_val in accumulated_context.items():
                 if ctx_key == "input":
                     continue
@@ -1266,12 +1312,22 @@ async def run_procedure_orchestration(
 
             schema_str = json.dumps(fn_schema, indent=2) if fn_schema else "{}"
 
+            mapping_hint = ""
+            if pre_resolved:
+                mapping_hint = (
+                    f"\n## Pre-Resolved Parameters\n"
+                    f"The following parameters have been pre-resolved from input mappings. "
+                    f"Use these exact values:\n```json\n"
+                    f"{json.dumps(pre_resolved, indent=2, default=str)}\n```\n"
+                )
+
             system_prompt = (
                 f"You are executing step {step_num} of a procedure.\n\n"
                 f"## Step: {step_name}\n"
                 f"## Instructions\n{instructions}\n\n"
                 f"## Required Function: `{tool_name}`\n"
                 f"Parameter schema:\n```json\n{schema_str}\n```\n\n"
+                f"{mapping_hint}"
                 f"## Available Data\n{ctx_formatted}\n\n"
                 f"## RULES\n"
                 f"- You MUST make a tool call to `{tool_name}`. Do NOT respond with text.\n"
@@ -1396,11 +1452,32 @@ async def run_procedure_orchestration(
 
         if step_succeeded:
             step_result["status"] = "success"
-            accumulated_context[f"step_{step_num}"] = {
-                "name": step_name,
-                "status": "success",
-                "result": step_result["result"],
-            }
+            step_output = step_result["result"]
+            if (
+                output_mapping
+                and isinstance(output_mapping, dict)
+                and isinstance(step_output, dict)
+            ):
+                from mcpworks_api.services.jsonpath import apply_output_mapping
+
+                extracted, out_errors = apply_output_mapping(output_mapping, step_output)
+                if out_errors:
+                    logger.warning(
+                        "procedure_output_mapping_partial",
+                        step=step_name,
+                        errors=out_errors,
+                    )
+                accumulated_context[f"step_{step_num}"] = {
+                    "name": step_name,
+                    "status": "success",
+                    "result": extracted if extracted else step_output,
+                }
+            else:
+                accumulated_context[f"step_{step_num}"] = {
+                    "name": step_name,
+                    "status": "success",
+                    "result": step_output,
+                }
         elif failure_policy == "skip":
             step_result["status"] = "skipped"
             accumulated_context[f"step_{step_num}"] = {

--- a/tests/unit/test_jsonpath.py
+++ b/tests/unit/test_jsonpath.py
@@ -1,0 +1,117 @@
+"""Unit tests for lightweight JSONPath resolver."""
+
+import pytest
+
+from mcpworks_api.services.jsonpath import (
+    JSONPathError,
+    apply_output_mapping,
+    resolve,
+    resolve_input_mapping,
+    validate_expression,
+)
+
+
+class TestResolve:
+    def test_simple_field(self):
+        assert resolve("$.name", {"name": "hello"}) == "hello"
+
+    def test_nested_field(self):
+        assert resolve("$.a.b.c", {"a": {"b": {"c": 42}}}) == 42
+
+    def test_array_index(self):
+        assert resolve("$.posts[0]", {"posts": ["first", "second"]}) == "first"
+
+    def test_array_index_nested(self):
+        ctx = {"posts": [{"text": "hello"}, {"text": "world"}]}
+        assert resolve("$.posts[1].text", ctx) == "world"
+
+    def test_step_chaining(self):
+        ctx = {"steps": {"post-root": {"result": {"uri": "at://did/post/1", "cid": "abc123"}}}}
+        assert resolve("$.steps.post-root.result.uri", ctx) == "at://did/post/1"
+
+    def test_missing_key_raises(self):
+        with pytest.raises(JSONPathError, match="Key 'missing' not found"):
+            resolve("$.missing", {"name": "hello"})
+
+    def test_index_out_of_range(self):
+        with pytest.raises(JSONPathError, match="out of range"):
+            resolve("$.posts[5]", {"posts": ["a", "b"]})
+
+    def test_index_on_non_list(self):
+        with pytest.raises(JSONPathError, match="Cannot index"):
+            resolve("$.name[0]", {"name": "hello"})
+
+    def test_field_on_non_dict(self):
+        with pytest.raises(JSONPathError, match="Cannot access"):
+            resolve("$.name.sub", {"name": "hello"})
+
+    def test_missing_dollar_prefix(self):
+        with pytest.raises(JSONPathError, match="must start with"):
+            resolve("name", {"name": "hello"})
+
+    def test_empty_path(self):
+        with pytest.raises(JSONPathError, match="Empty path"):
+            resolve("$.", {"name": "hello"})
+
+
+class TestValidateExpression:
+    def test_valid_simple(self):
+        assert validate_expression("$.name") is None
+
+    def test_valid_nested(self):
+        assert validate_expression("$.a.b.c") is None
+
+    def test_valid_array(self):
+        assert validate_expression("$.posts[0]") is None
+
+    def test_valid_mixed(self):
+        assert validate_expression("$.steps.post-root.result.uri") is None
+
+    def test_invalid_no_prefix(self):
+        assert validate_expression("name") is not None
+
+    def test_invalid_empty(self):
+        assert validate_expression("$.") is not None
+
+    def test_not_string(self):
+        assert validate_expression(123) is not None
+
+
+class TestResolveInputMapping:
+    def test_full_mapping(self):
+        mapping = {"text": "$.posts[0]", "parent_uri": "$.steps.post-root.result.uri"}
+        ctx = {
+            "posts": ["Hello world"],
+            "steps": {"post-root": {"result": {"uri": "at://x"}}},
+        }
+        resolved, errors = resolve_input_mapping(mapping, ctx)
+        assert errors == []
+        assert resolved == {"text": "Hello world", "parent_uri": "at://x"}
+
+    def test_partial_failure(self):
+        mapping = {"text": "$.posts[0]", "missing": "$.nonexistent"}
+        ctx = {"posts": ["Hello"]}
+        resolved, errors = resolve_input_mapping(mapping, ctx)
+        assert resolved == {"text": "Hello"}
+        assert len(errors) == 1
+        assert "missing" in errors[0]
+
+
+class TestApplyOutputMapping:
+    def test_extract_fields(self):
+        mapping = {"post_uri": "$.uri", "post_cid": "$.cid"}
+        result = {"success": True, "uri": "at://x", "cid": "abc"}
+        extracted, errors = apply_output_mapping(mapping, result)
+        assert errors == []
+        assert extracted == {"post_uri": "at://x", "post_cid": "abc"}
+
+    def test_non_dict_result(self):
+        mapping = {"value": "$.x"}
+        extracted, errors = apply_output_mapping(mapping, "not a dict")
+        assert len(errors) == 1
+        assert extracted == {}
+
+    def test_missing_field(self):
+        mapping = {"value": "$.missing"}
+        extracted, errors = apply_output_mapping(mapping, {"other": 1})
+        assert len(errors) == 1

--- a/tests/unit/test_procedure_mappings.py
+++ b/tests/unit/test_procedure_mappings.py
@@ -1,0 +1,35 @@
+"""Unit tests for procedure step input/output mapping validation."""
+
+from mcpworks_api.services.jsonpath import validate_expression
+
+
+class TestMappingValidation:
+    def test_valid_simple_path(self):
+        assert validate_expression("$.text") is None
+
+    def test_valid_array_path(self):
+        assert validate_expression("$.posts[0]") is None
+
+    def test_valid_step_chaining(self):
+        assert validate_expression("$.steps.post-root.result.uri") is None
+
+    def test_valid_nested_array(self):
+        assert validate_expression("$.data[2].name") is None
+
+    def test_invalid_no_dollar(self):
+        assert validate_expression("posts[0]") is not None
+
+    def test_invalid_empty(self):
+        assert validate_expression("$.") is not None
+
+    def test_step_ordering_logic(self):
+        step_names_so_far = ["post-root"]
+        expr = "$.steps.post-root.result.uri"
+        ref_step = expr.split(".")[2]
+        assert ref_step in step_names_so_far
+
+    def test_step_ordering_fails_for_future_step(self):
+        step_names_so_far = ["post-root"]
+        expr = "$.steps.post-reply.result.uri"
+        ref_step = expr.split(".")[2]
+        assert ref_step not in step_names_so_far


### PR DESCRIPTION
## Summary

- Procedure steps can declare `input_mapping` and `output_mapping` with JSONPath expressions
- Input mappings resolve deterministically **before** the inner AI sees the step — no LLM interpretation for data flow
- Output mappings extract specific fields from step results into accumulated context for downstream steps
- Lightweight JSONPath resolver (stdlib only, no external deps) — field access, array indexing, nested paths, step chaining
- Authoring-time validation: syntax check + step ordering (can't reference a future step)
- Backward compatible — steps without mappings behave identically to current behavior

## Production impact

Fixes `post-bluesky-thread` procedure which failed at 0% success rate because the inner AI couldn't extract `$.posts[0]` from an array. With `input_mapping: {text: "$.posts[0]"}`, the value is pre-resolved.

## Example

```yaml
steps:
  - name: post-root
    function_ref: social.post-to-bluesky
    input_mapping:
      text: "$.posts[0]"
    output_mapping:
      post_uri: "$.uri"
      post_cid: "$.cid"
  - name: post-reply
    function_ref: social.reply-to-post
    input_mapping:
      text: "$.posts[1]"
      parent_uri: "$.steps.post-root.result.post_uri"
```

## Test plan

- [ ] 717 unit tests pass (31 new: JSONPath resolver, validation, mapping integration)
- [ ] Update `post-bluesky-thread` procedure with input_mapping and verify thread posting works
- [ ] Create procedure with invalid JSONPath — verify authoring-time rejection
- [ ] Create procedure referencing future step — verify ordering validation
- [ ] Existing procedures without mappings continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)