### PR TITLE
Pin routing to path; deprecate subdomain routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@ APP_PORT=8000
 # BASE_DOMAIN=mcpworks.io
 # BASE_SCHEME=https
 # ALLOW_REGISTRATION=false
+# URL routing — "path" is canonical (api.<domain>/mcp/<endpoint>/<ns>).
+# "subdomain"/"both" are deprecated: they require wildcard/on-demand TLS, which is
+# fragile to operate. Leave as path unless you specifically need vanity subdomains.
+ROUTING_MODE=path
 
 # Email - SMTP (alternative to Resend for self-hosted)
 # SMTP_HOST=

--- a/infra/server0/docker-compose.yml
+++ b/infra/server0/docker-compose.yml
@@ -44,6 +44,11 @@ services:
     container_name: mcpworks-api
     restart: unless-stopped
     env_file: .env
+    environment:
+      # Routing pinned to path; subdomain routing is deprecated (wildcard-subdomain
+      # edge TLS proved fragile — incident 2026-06-03). Overrides any ROUTING_MODE
+      # left in .env. Path uses a single api.<domain> cert; no wildcard/on-demand TLS.
+      ROUTING_MODE: path
     ports:
       - "8000:8000"
     volumes:

--- a/src/mcpworks_api/config.py
+++ b/src/mcpworks_api/config.py
@@ -35,7 +35,11 @@ class Settings(BaseSettings):
     )
     routing_mode: Literal["path", "subdomain", "both"] = Field(
         default="path",
-        description="URL routing: path (/mcp/create/ns), subdomain (ns.create.domain), or both",
+        description=(
+            "URL routing. 'path' (api.<domain>/mcp/<endpoint>/<ns>) is canonical. "
+            "'subdomain'/'both' are DEPRECATED — they need wildcard/on-demand TLS, "
+            "which is operationally fragile; slated for removal."
+        ),
     )
     allow_registration: bool = Field(
         default=False,


### PR DESCRIPTION
## Why

Subdomain routing (`{ns}.{endpoint}.mcpworks.io`) needs wildcard / on-demand TLS on the edge, which proved fragile: on **2026-06-03** the wildcard-subdomain edge (`146.190.249.118`) failed its TLS handshake (`tlsv1 alert internal error`, no cert served), knocking out the `create`/`run` MCP endpoints — while `api.mcpworks.io` (path routing, single Let's Encrypt cert) stayed healthy the whole time. Subdomain routing is already non-default and entirely flag-gated.

## What

- **`infra/server0/docker-compose.yml`** — pin `ROUTING_MODE=path` on the `api` service `environment:` (overrides any value left in the host `.env`), so prod stops accepting subdomain Host headers.
- **`.env.example`** — document path as canonical; subdomain/both as deprecated.
- **`config.py`** — mark `subdomain`/`both` DEPRECATED in the field description.

`url_builder` already emits path URLs in path mode, so all client-facing URLs follow automatically — no code change needed there.

## Deliberately *not* in this PR

- Removing `SubdomainMiddleware` / the subdomain code — deprecate-then-remove. Pull edge access logs for `*.create/run/agent.mcpworks.io` to confirm no real traffic first.
- Decommissioning the wildcard DNS + edge on-demand TLS — an edge-host infra step (also resolves the current `ssl_*` busybox checks).

## Deploy note

Merging to `main` auto-deploys to server0, which applies the pin. Path routing already works in prod (verified: `api.mcpworks.io/mcp/{create,run}/<ns>` → 200), so this just formalizes the working mode; subdomain is already effectively dead due to the edge TLS failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)