### PR TITLE
Finish subdomain-routing deprecation: edge config + infra docs + deploy filter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,14 @@ name: Deploy
 on:
   push:
     branches: [main]
+    # Don't redeploy prod (which restarts the API and drops live MCP connections)
+    # for changes that can't affect the running server0 service. Note: infra/server0/**
+    # IS deployed, so it is deliberately NOT ignored here.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'specs/**'
+      - 'infra/edge/**'
   workflow_dispatch:
 
 concurrency:

--- a/infra/MIGRATION-TO-POP11.md
+++ b/infra/MIGRATION-TO-POP11.md
@@ -8,7 +8,7 @@
 ```
 [INTERNET]
      |
-api.mcpworks.io (159.203.30.199)    <-- Caddy only, TLS + reverse proxy
+api.mcpworks.io (146.190.249.118)   <-- Caddy only, TLS + reverse proxy (mcpworks-edge, tor1)
      | WireGuard (10.100.0.1 <-> 10.100.0.3)
      |
 server0.pop11 (10.0.0.14)           <-- API + Postgres + Redis + Sandbox
@@ -172,7 +172,7 @@ doctl databases delete <valkey-cluster-id>
 GitHub Actions deploy workflow needs updating:
 
 - `DEPLOY_HOST` changes to server0's public-reachable address
-  - Option A: SSH through api.mcpworks.io as jump host (`ssh -J root@159.203.30.199 root@10.100.0.3`)
+  - Option A: SSH through api.mcpworks.io as jump host (`ssh -J root@api.mcpworks.io root@10.100.0.3`) — use the hostname, not a hardcoded IP (the edge IP can change on rebuild)
   - Option B: SSH directly to server0 if it has a public IP or port forward
 - Deploy path stays `/opt/mcpworks`
 - Docker compose file reference changes
@@ -195,10 +195,10 @@ The WG tunnel is now a critical path. Add monitoring:
 
 ## Outbound NAT
 
-server0 and server1 use api.mcpworks.io as their default gateway for internet-bound traffic via WireGuard. This is already configured — outbound from server0 exits via 159.203.30.199.
+server0 and server1 use the edge (api.mcpworks.io) as their default gateway for internet-bound traffic via WireGuard. This is already configured — outbound from server0 exits via the edge's public IP (146.190.249.118).
 
 Verify:
 ```bash
 # On server0
-curl -s ifconfig.me  # Should show 159.203.30.199
+curl -s ifconfig.me  # Should show the edge public IP (146.190.249.118)
 ```

--- a/infra/POP11-ARCHITECTURE.md
+++ b/infra/POP11-ARCHITECTURE.md
@@ -14,11 +14,16 @@ MCPWorks production infrastructure runs on-premises on Hyper-V VMs ("POP11") wit
 
 | Host | Address | Role | Resources |
 |------|---------|------|-----------|
-| **api.mcpworks.io** | 159.203.30.199 (public), 10.100.0.1 (WG) | Edge proxy (Caddy only) | DO droplet, minimal |
+| **api.mcpworks.io** | 146.190.249.118 (public), 10.100.0.1 (WG) | Edge proxy (Caddy only) | DO droplet `mcpworks-edge` (tor1) |
 | **server0.pop11** | 10.0.0.14 (LAN), 10.100.0.3 (WG) | MCPWorks platform (API, Postgres, Redis, sandbox) | Hyper-V VM, 12 vCPU, dynamic RAM |
 | **server1.pop11** | TBD (LAN), 10.100.0.4 (WG) | GenOps (genops.dev) | Hyper-V VM (planned) |
 | **maeve.pop11** | 10.0.0.81 (LAN only) | Hyper-V host, GPU (RTX 3090), Ollama | NOT on WireGuard |
 | **monolith.pop11** | 10.0.0.41 (LAN), 10.100.0.2 (WG) | Dev machine | Simon's workstation |
+
+> **Prefer hostnames over IPs.** Reach the edge as `api.mcpworks.io` (DNS → the
+> `mcpworks-edge` droplet). The public IP can change on a droplet rebuild — it
+> moved from `159.203.30.199` (now **decommissioned** — do not reuse; DigitalOcean
+> may have reassigned it to another customer) to `146.190.249.118` on 2026-06-03.
 
 ## Network Architecture
 
@@ -27,7 +32,7 @@ MCPWorks production infrastructure runs on-premises on Hyper-V VMs ("POP11") wit
      │
      ▼
 ┌─────────────────────┐
-│  api.mcpworks.io    │  DO tor1, 159.203.30.199
+│  api.mcpworks.io    │  DO tor1, 146.190.249.118
 │  Caddy (TLS only)   │  WG: 10.100.0.1
 │  + agent containers │  (agents still here temporarily)
 │  + socat proxy      │

--- a/infra/edge/Caddyfile
+++ b/infra/edge/Caddyfile
@@ -36,38 +36,9 @@ api.mcpworks.io {
     }
 }
 
-# ──────────────────────────────────────────────────────────────
-# DEPRECATED: Wildcard subdomain blocks (transition period)
-#
-# These exist for backward compatibility with clients still using
-# subdomain-based URLs like {ns}.create.mcpworks.io.
-# Set ROUTING_MODE=both in the API to enable.
-# Remove after transition period (90 days from 2026-03-30).
-# ──────────────────────────────────────────────────────────────
-
-# (Commented out — uncomment if ROUTING_MODE=both is needed)
-#
-# on_demand_tls {
-#     ask http://10.100.0.3:8000/v1/internal/verify-domain
-# }
-#
-# *.create.mcpworks.io {
-#     tls { on_demand }
-#     reverse_proxy 10.100.0.3:8000
-#     header { X-Content-Type-Options nosniff; X-Frame-Options DENY; -Server }
-# }
-#
-# *.run.mcpworks.io {
-#     tls { on_demand }
-#     reverse_proxy 10.100.0.3:8000
-#     header { X-Content-Type-Options nosniff; X-Frame-Options DENY; -Server }
-# }
-#
-# *.agent.mcpworks.io {
-#     tls { on_demand }
-#     reverse_proxy 10.100.0.3:8000
-#     header { X-Content-Type-Options nosniff; X-Frame-Options DENY; -Server }
-# }
+# Subdomain routing ({ns}.create/run/agent.mcpworks.io) was removed 2026-06-03.
+# Path routing via api.mcpworks.io is canonical (the API runs ROUTING_MODE=path);
+# it needs no wildcard / on-demand TLS — just the single api.mcpworks.io cert above.
 
 # GenOps (genops.dev) -> server1.pop11
 genops.dev {


### PR DESCRIPTION
Follow-up cleanup after pinning routing to path (#109), resolving the 2026-06-03 subdomain-TLS incident.

## Changes

- **`infra/edge/Caddyfile`** — remove the already-commented-out wildcard subdomain blocks (`*.create/run/agent.mcpworks.io` + `on_demand_tls`); leave a one-line breadcrumb. No runtime change — the live edge already serves only `api.mcpworks.io`.
- **`infra/POP11-ARCHITECTURE.md` / `infra/MIGRATION-TO-POP11.md`** — fix the stale edge IP. Verified via `doctl`: the one edge is the **`mcpworks-edge`** droplet (`146.190.249.118`, tor1). The docs' `159.203.30.199` is a **decommissioned** droplet IP — no longer ours (DO may have reassigned it), so `ssh -J root@159.203.30.199 …` was pointing at a potential stranger's box. SSH jump host now uses the `api.mcpworks.io` **hostname** (prefer hostnames over hardcoded IPs).
- **`.github/workflows/deploy.yml`** — add `paths-ignore` (`**.md`, `docs/`, `specs/`, `infra/edge/`) so doc/spec/edge-only changes stop redeploying prod (each deploy restarts the API and drops live MCP connections). `infra/server0/**` is deliberately **not** ignored — the prod compose still deploys.

## Still outside this PR (needs your go-ahead)

- **Delete the stale wildcard DNS records** `*.create`, `*.run`, `*.agent` (→ `146.190.249.118`). These resolve to an edge that no longer serves them; removing them clears busybox's `ssl_*` / TLS-error alerts. Ready-to-run `doctl` commands proposed separately.
- **Update busybox** to stop checking the subdomains (or repoint to `api.mcpworks.io` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)